### PR TITLE
Remove types

### DIFF
--- a/q2cli/cli.py
+++ b/q2cli/cli.py
@@ -27,6 +27,10 @@ class QiimeCLI(click.MultiCommand):
 
     def list_commands(self, ctx):
         plugins = list(sorted(self._plugin_manager.plugins.keys()))
+        for idx, key in enumerate(plugins):
+            plugin = self._plugin_manager.plugins[key]
+            if not plugin.methods or not plugin.visualizers:
+                del plugins[idx]
         builtins = list(sorted(self._builtin_commands.keys()))
         commands = builtins + plugins
         return commands

--- a/q2cli/cli.py
+++ b/q2cli/cli.py
@@ -29,7 +29,7 @@ class QiimeCLI(click.MultiCommand):
         plugins = list(sorted(self._plugin_manager.plugins.keys()))
         for idx, key in enumerate(plugins):
             plugin = self._plugin_manager.plugins[key]
-            if not plugin.methods or not plugin.visualizers:
+            if not plugin.methods and not plugin.visualizers:
                 del plugins[idx]
         builtins = list(sorted(self._builtin_commands.keys()))
         commands = builtins + plugins


### PR DESCRIPTION
Stops commands from being displayed if their associated plugin does not have methods or a visualizer