### PR TITLE
ENH: more user friendly message when a command doesn't exist

### DIFF
--- a/q2cli/cli.py
+++ b/q2cli/cli.py
@@ -55,6 +55,10 @@ class QiimeCLI(click.MultiCommand):
                         return _build_method_command(
                             name, plugin.methods[name])
                     else:
+                        if name not in plugin.visualizers:
+                            click.echo(("%s is not a valid command for plugin "
+                                        "%s.") % (name, plugin.name), err=True)
+                            ctx.exit(1)
                         return _build_visualizer_command(
                             name, plugin.visualizers[name])
             # TODO: pass help=plugin.description, pending its existence:


### PR DESCRIPTION
As an example:

```bash
$ qiime types feature-table --help
feature-table is not a valid command for plugin types.
```

Whereas the prior behavior was:

```bash
$ qiime types feature-table --help
Traceback (most recent call last):
  File "/Users/mcdonadt/miniconda3/envs/q2test/bin/qiime", line 6, in <module>
    sys.exit(q2cli.cli.main())
  File "/Users/mcdonadt/miniconda3/envs/q2test/lib/python3.5/site-packages/q2cli-0.0.1-py3.5.egg/q2cli/cli.py", line 242, in main
  File "/Users/mcdonadt/miniconda3/envs/q2test/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/mcdonadt/miniconda3/envs/q2test/lib/python3.5/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/mcdonadt/miniconda3/envs/q2test/lib/python3.5/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/mcdonadt/miniconda3/envs/q2test/lib/python3.5/site-packages/click/core.py", line 1055, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)
  File "/Users/mcdonadt/miniconda3/envs/q2test/lib/python3.5/site-packages/click/core.py", line 1094, in resolve_command
    cmd = self.get_command(ctx, cmd_name)
  File "/Users/mcdonadt/miniconda3/envs/q2test/lib/python3.5/site-packages/q2cli-0.0.1-py3.5.egg/q2cli/cli.py", line 59, in get_command
KeyError: 'feature-table'
```