### PR TITLE
ENH: support discovery of plugin citations and user support text

### DIFF
--- a/q2cli/_info.py
+++ b/q2cli/_info.py
@@ -34,11 +34,10 @@ def _echo_plugins():
         # https://github.com/qiime2/qiime2/issues/82
         click.secho('No plugins are currently installed.\nYou can browse '
                     'the official QIIME 2 plugins at: '
-                    'https://github.com/qiime2')
+                    'http://2.qiime.org/Plugins')
     else:
         for name, plugin in installed_plugins.items():
-            click.echo('%s %s (%s)' %
-                       (name, plugin.version, plugin.website))
+            click.echo('%s %s' % (name, plugin.version))
 
 
 def _echo_installed_packages():
@@ -62,6 +61,12 @@ def info(py_packages):
     if py_packages:
         click.secho('\nInstalled Python packages', fg='green')
         _echo_installed_packages()
-    click.secho('\nTo get help with QIIME, visit %s.' % qiime.sdk.HELP_URL)
-    click.secho('If you use QIIME in any published work, please cite %s' %
-                qiime.sdk.CITATION)
+
+    click.secho('\nGetting help', fg='green')
+    click.secho('To get help with QIIME 2, visit %s.' % qiime.sdk.HELP_URL)
+
+    click.secho('\nCiting QIIME 2', fg='green')
+    click.secho('If you use QIIME 2 in any published work, you should cite '
+                'QIIME 2 and the plugins that you used. To find the relevant '
+                'citations, run:')
+    click.secho('\tqiime tools citations')

--- a/q2cli/_tools.py
+++ b/q2cli/_tools.py
@@ -136,3 +136,19 @@ def extract(path, output_dir):
         raise click.BadParameter(
             '%s is not a QIIME Result. Only QIIME Visualizations and Artifacts'
             ' can be extracted.' % path)
+
+
+@tools.command(help='Present citations for QIIME and installed plugins.')
+def citations():
+    click.secho('If you use QIIME 2 in any published work, you should cite '
+                'QIIME 2 and the plugins that you used. The citations for '
+                'QIIME and all installed plugins follow.')
+    click.secho('\nQIIME 2 framework and command line interface', fg='green')
+    click.secho('Pending a QIIME 2 publication, please cite QIIME using the '
+                'original publication: %s' % qiime.sdk.CITATION)
+
+    plugin_manager = qiime.sdk.PluginManager()
+    installed_plugins = plugin_manager.plugins
+    for name, plugin in sorted(installed_plugins.items()):
+        click.secho('\n%s' % name, fg='green')
+        click.secho(plugin.citation_text)

--- a/q2cli/cli.py
+++ b/q2cli/cli.py
@@ -72,9 +72,13 @@ class QiimeCLI(click.MultiCommand):
                     else:
                         return _build_visualizer_command(
                             name, plugin.visualizers[action_name])
-            # TODO: pass help=plugin.description, pending its existence:
-            # https://github.com/qiime2/qiime2/issues/81
-            return PluginCommand(ctx)
+            # TODO: pass short_help=plugin.description, pending its
+            # existence: https://github.com/qiime2/qiime2/issues/81
+            _support = 'Getting user support: %s' % plugin.user_support_text
+            _citing = 'Citing this plugin: %s' % plugin.citation_text
+            _website = 'Plugin website: %s' % plugin.website
+            _help = '\n\n'.join([_website, _support, _citing])
+            return PluginCommand(ctx, short_help='', help=_help)
         else:
             return None
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license='BSD-3-Clause',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['click', 'qiime >= 2.0.0', 'pip'],
+    install_requires=['click', 'qiime >= 2.0.2', 'pip'],
     entry_points='''
         [console_scripts]
         qiime=q2cli.cli:main


### PR DESCRIPTION
Here's what this looks like...

``qiime info`` tells you how to access all citations:

![screenshot 2016-08-08 13 33 45](https://cloud.githubusercontent.com/assets/192372/17495158/cc6b01e2-5d6c-11e6-8909-96e60aae396b.png)

which looks like the following: 

![screenshot 2016-08-08 13 02 53](https://cloud.githubusercontent.com/assets/192372/17494571/21a0ff5c-5d6a-11e6-9f6e-5f37b1925bf8.png)

(A little bit ugly, but it's a big text dump so I don't really know how to get around it. We can optionally present subsets to the user in the future.)

Calling ``--help`` on a plugin also presents the citation, the website, and how to get help:

![screenshot 2016-08-08 13 32 56](https://cloud.githubusercontent.com/assets/192372/17495124/a590f586-5d6c-11e6-8859-79ee4cb42a46.png)

