### PR TITLE
ENH/REF/MAINT: use new "actions" API; flexible support for output file extensions

### DIFF
--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -176,21 +176,13 @@ class ArtifactHandler(GeneratedHandler):
 class ResultHandler(GeneratedHandler):
     prefix = 'o_'
 
-    def __init__(self, extension, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.extension = extension
-
     def get_click_options(self):
         yield click.Option(['--' + self.cli_name],
                            type=click.Path(exists=False, dir_okay=False),
                            help="Output %r" % self.semtype)
 
     def get_value(self, arguments, fallback=None):
-        path = self._locate_value(arguments, fallback)
-        if not path.endswith(self.extension):
-            path += self.extension
-
-        return path
+        return self._locate_value(arguments, fallback)
 
 
 def parameter_handler_factory(name, semtype, default=NoDefault):

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -50,7 +50,7 @@ class CliTests(unittest.TestCase):
 
     def test_plugin_list_commands(self):
         # plugin commands are present including method (from function),
-        # method (from markdown) and visualization
+        # method (from markdown) and visualizer
         qiime_cli = RootCommand()
         command = qiime_cli.get_command(ctx=None, name='dummy-plugin')
         commands = command.list_commands(ctx=None)


### PR DESCRIPTION
Supports actions generically instead of separate handling of methods and visualizers. Supports flexible handling of output file extensions that will work when pipeline actions and new result types are added to the framework in the future.

Depends on https://github.com/qiime2/qiime2/pull/118 being merged.