### PR TITLE
ENH: adds support for None as a default value

### DIFF
--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -288,6 +288,9 @@ class RegularParameterHandler(GeneratedHandler):
 
     def get_value(self, arguments, fallback=None):
         value = self._locate_value(arguments, fallback)
-        if self.get_type() is bool:
+        if value is None:
+            return None
+        elif self.get_type() is bool:
             return value
-        return self.semtype.decode(value)
+        else:
+            return self.semtype.decode(value)


### PR DESCRIPTION
I tested this locally by modifying an existing method to have a default parameter of `None`. 

This depends on qiime2/qiime2#158