### PR TITLE
ENH: cached CLI state for performance improvements

### DIFF
--- a/q2cli/__main__.py
+++ b/q2cli/__main__.py
@@ -20,5 +20,6 @@ import q2cli.info
 def cli():
     pass
 
+
 if __name__ is '__main__':
     cli()

--- a/q2cli/cache.py
+++ b/q2cli/cache.py
@@ -182,7 +182,7 @@ class DeploymentCache:
         click.secho(
             "QIIME is caching your current deployment for improved "
             "performance. This may take a few moments and should only happen "
-            "once per deployment.", fg='yellow')
+            "once per deployment.", fg='yellow', err=True)
 
         cache_dir = self._cache_dir
 

--- a/q2cli/cache.py
+++ b/q2cli/cache.py
@@ -1,0 +1,281 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+
+class DeploymentCache:
+    """Cached CLI state for a QIIME deployment.
+
+    In this context, a QIIME deployment is the set of installed Python
+    packages, including their exact versions, that register one or more QIIME 2
+    plugins. The exact version of q2cli is also included in the deployment.
+
+    The deployment cache stores the current deployment's package names and
+    versions in a requirements.txt file under the cache directory. This file is
+    used to determine if the cache is outdated. If the cache is determined to
+    be outdated, it will be refreshed based on the current deployment state.
+    Thus, adding, removing, upgrading, or downgrading a plugin package or q2cli
+    itself will trigger a cache refresh.
+
+    Two mechanisms are provided to force a cache refresh. Setting the
+    environment variable Q2CLIDEV to any value will cause the cache to be
+    refreshed upon instantiation. Calling `.refresh()` will also refresh the
+    cache. Forced refreshing of the cache is useful for plugin and/or q2cli
+    developers who want their changes to take effect in the CLI without
+    changing their package versions.
+
+    Cached CLI state is stored in a state.json file under the cache directory.
+    It is not a public file format and it is not versioned. q2cli is included
+    as part of the QIIME deployment so that the cached state can always be read
+    (or recreated as necessary) by the currently installed version of q2cli.
+
+    This class is intended to be a singleton because it is responsible for
+    managing the on-disk cache. Having more than one instance managing the
+    cache has the possibility of two instances clobbering the cache (e.g. in a
+    multithreaded/multiprocessing situation). Also, having a single instance
+    improves performance by only reading and/or refreshing the cache a
+    single time during its lifetime. Having two instances could, for example,
+    trigger two cache refreshes if Q2CLIDEV is set. To support these use-cases,
+    a module-level `CACHE` variable stores a single instance of this class.
+
+    """
+
+    # Public API
+
+    def __init__(self):
+        import os
+
+        # Indicates if the cache has been refreshed. For performance purposes,
+        # the cache is only refreshed a single time (at maximum) during the
+        # object's lifetime. Thus, "hot reloading" isn't supported, but this
+        # shouldn't be necessary for the CLI.
+        self._refreshed = False
+
+        self._cache_dir = self._get_cache_dir()
+
+        refresh = 'Q2CLIDEV' in os.environ
+        self._state = self._get_cached_state(refresh=refresh)
+
+    @property
+    def plugins(self):
+        """Decoded JSON object representing CLI state on a per-plugin basis."""
+        return self._state['plugins']
+
+    def refresh(self):
+        """Trigger a forced refresh of the cache.
+
+        If the cache has already been refreshed (either by this method or at
+        some point during instantiation), this method is a no-op.
+
+        """
+        if not self._refreshed:
+            self._state = self._get_cached_state(refresh=True)
+
+    # Private API
+
+    def _get_cache_dir(self):
+        import os
+        import os.path
+        import q2cli.util
+
+        cache_dir = os.path.join(q2cli.util.get_app_dir(), 'cache')
+        os.makedirs(cache_dir, exist_ok=True)
+        return cache_dir
+
+    def _get_cached_state(self, refresh):
+        import json
+        import os.path
+
+        current_requirements = self._get_current_requirements()
+        state_path = os.path.join(self._cache_dir, 'state.json')
+
+        # The cache must be refreshed in the following cases:
+
+        # 1) We have been explicitly told to refresh.
+        if refresh:
+            self._cache_current_state(current_requirements)
+        # 2) The current deployment requirements are different than the cached
+        #    requirements.
+        elif current_requirements != self._get_cached_requirements():
+            self._cache_current_state(current_requirements)
+        # 3) The cached state file does not exist.
+        elif not os.path.exists(state_path):
+            self._cache_current_state(current_requirements)
+
+        # Now that the cache is up-to-date, read it.
+        try:
+            with open(state_path, 'r') as fh:
+                return json.load(fh)
+        except json.JSONDecodeError:
+            # 4) The cached state file can't be read as JSON.
+            self._cache_current_state(current_requirements)
+            with open(state_path, 'r') as fh:
+                return json.load(fh)
+
+    # NOTE: The private methods below are all used internally within
+    # `_get_cached_state`.
+
+    def _get_current_requirements(self):
+        """Includes installed versions of q2cli and QIIME 2 plugins."""
+        import os
+        import pkg_resources
+        import q2cli
+
+        reqs = {
+            pkg_resources.Requirement.parse('q2cli == %s' % q2cli.__version__)
+        }
+
+        # A distribution (i.e. Python package) can have multiple plugins, where
+        # each plugin is its own entry point. A distribution's `Requirement` is
+        # hashable, and the `set` is used to exclude duplicates. Thus, we only
+        # gather the set of requirements for all installed Python packages
+        # containing one or more plugins. It is not necessary to track
+        # individual plugin names and versions in order to determine if the
+        # cache is outdated.
+        #
+        # TODO: this code is copied from
+        # `qiime.sdk.PluginManager.iter_entry_points`. Importing QIIME is
+        # currently slow, and it adds ~600-700ms to any CLI command. This makes
+        # the CLI pretty unresponsive, especially when running help/informative
+        # commands. Uncomment the following lines when
+        # https://github.com/qiime2/qiime2/issues/151 is fixed:
+        #
+        # for ep in qiime.sdk.PluginManager.iter_entry_points():
+        #     reqs.add(ep.dist.as_requirement())
+        #
+        for entry_point in pkg_resources.iter_entry_points(
+                group='qiime.plugins'):
+            if entry_point.name != 'dummy-plugin' or 'QIIMETEST' in os.environ:
+                reqs.add(entry_point.dist.as_requirement())
+
+        return reqs
+
+    def _get_cached_requirements(self):
+        import os.path
+        import pkg_resources
+
+        path = os.path.join(self._cache_dir, 'requirements.txt')
+
+        if not os.path.exists(path):
+            # No cached requirements. The empty set will always trigger a cache
+            # refresh because the current requirements will, at minimum,
+            # contain q2cli.
+            return set()
+        else:
+            with open(path, 'r') as fh:
+                contents = fh.read()
+            try:
+                return set(pkg_resources.parse_requirements(contents))
+            except pkg_resources.RequirementParseError:
+                # Unreadable cached requirements, trigger a cache refresh.
+                return set()
+
+    def _cache_current_state(self, requirements):
+        import json
+        import os.path
+        import click
+
+        click.secho(
+            "QIIME is caching your current deployment for improved "
+            "performance. This may take a few moments and should only happen "
+            "once per deployment.", fg='yellow')
+
+        cache_dir = self._cache_dir
+
+        path = os.path.join(cache_dir, 'requirements.txt')
+        with open(path, 'w') as fh:
+            for req in requirements:
+                # `str(Requirement)` is the recommended way to format a
+                # `Requirement` that can be read with `Requirement.parse`.
+                fh.write(str(req))
+                fh.write('\n')
+
+        state = self._get_current_state()
+
+        path = os.path.join(cache_dir, 'state.json')
+        with open(path, 'w') as fh:
+            json.dump(state, fh)
+
+        self._refreshed = True
+
+    def _get_current_state(self):
+        """Get current CLI state as an object that is serializable as JSON.
+
+        WARNING: This method is very slow and should only be called when the
+        cache needs to be refreshed.
+
+        """
+        import qiime.sdk
+
+        state = {
+            'plugins': {}
+        }
+
+        plugin_manager = qiime.sdk.PluginManager()
+        for name, plugin in plugin_manager.plugins.items():
+            state['plugins'][name] = self._get_plugin_state(plugin)
+
+        return state
+
+    def _get_plugin_state(self, plugin):
+        state = {
+            # TODO this conversion also happens in the framework
+            # (qiime/plugins.py) to generate an importable module name from a
+            # plugin's `.name` attribute. Centralize this knowledge in the
+            # framework, ideally as a machine-friendly plugin ID (similar to
+            # `Action.id`).
+            'id': plugin.name.replace('-', '_'),
+            'name': plugin.name,
+            'version': plugin.version,
+            'website': plugin.website,
+            'citation_text': plugin.citation_text,
+            'user_support_text': plugin.user_support_text,
+            'actions': {}
+        }
+
+        for id, action in plugin.actions.items():
+            state['actions'][id] = self._get_action_state(action)
+
+        return state
+
+    def _get_action_state(self, action):
+        state = {
+            'id': action.id,
+            'name': action.name,
+            'description': action.description,
+            'signature': {
+                # This preserves order of inputs, parameters, and outputs,
+                # which will be necessary when `Action.signature` retains API
+                # order: https://github.com/qiime2/qiime2/issues/70
+                'inputs': [],
+                'parameters': [],
+                'outputs': [],
+                'defaults': action.signature.defaults
+            }
+        }
+
+        # Inputs and outputs are handled the same. Parameters must be handled a
+        # little differently because they require an AST representation.
+        for group in 'inputs', 'outputs':
+            for name, (type, _) in getattr(action.signature, group).items():
+                state['signature'][group].append({
+                    'name': name,
+                    'repr': repr(type)
+                })
+
+        for name, (type, _) in action.signature.parameters.items():
+            state['signature']['parameters'].append({
+                'name': name,
+                'repr': repr(type),
+                'ast': type.to_ast()
+            })
+
+        return state
+
+
+# Singleton. Import and use this instance as necessary.
+CACHE = DeploymentCache()

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -7,33 +7,40 @@
 # ----------------------------------------------------------------------------
 
 import collections
-import itertools
 
 import click
-import qiime.sdk
 
-import q2cli.tools
+import q2cli.dev
 import q2cli.info
-import q2cli.handlers
-import q2cli.util
+import q2cli.tools
 
 
 class RootCommand(click.MultiCommand):
     """This class defers to either the PluginCommand or the builtin cmds"""
-    _builtin_commands = {'tools': q2cli.tools.tools,
-                         'info': q2cli.info.info}
+    _builtin_commands = collections.OrderedDict([
+        ('info', q2cli.info.info),
+        ('tools', q2cli.tools.tools),
+        ('dev', q2cli.dev.dev)
+    ])
 
     @property
     def _plugin_lookup(self):
-        plugin_manager = qiime.sdk.PluginManager()
+        import q2cli.cache
+        import q2cli.util
+
         name_map = {}
-        for plugin_name, plugin in plugin_manager.plugins.items():
-            if plugin.actions:
-                name_map[q2cli.util.to_cli_name(plugin_name)] = plugin
+        for name, plugin in q2cli.cache.CACHE.plugins.items():
+            if plugin['actions']:
+                name_map[q2cli.util.to_cli_name(name)] = plugin
         return name_map
 
     def list_commands(self, ctx):
-        builtins = sorted(self._builtin_commands)
+        import itertools
+
+        # Avoid sorting builtin commands as they have a predefined order based
+        # on applicability to users. For example, it isn't desirable to have
+        # the `dev` command listed before `info` and `tools`.
+        builtins = self._builtin_commands
         plugins = sorted(self._plugin_lookup)
         return itertools.chain(builtins, plugins)
 
@@ -48,9 +55,9 @@ class RootCommand(click.MultiCommand):
 
         # TODO: pass short_help=plugin.description, pending its
         # existence: https://github.com/qiime2/qiime2/issues/81
-        support = 'Getting user support: %s' % plugin.user_support_text
-        citing = 'Citing this plugin: %s' % plugin.citation_text
-        website = 'Plugin website: %s' % plugin.website
+        support = 'Getting user support: %s' % plugin['user_support_text']
+        citing = 'Citing this plugin: %s' % plugin['citation_text']
+        website = 'Plugin website: %s' % plugin['website']
         help_ = '\n\n'.join([website, support, citing])
 
         return PluginCommand(plugin, ctx, short_help='', help=help_)
@@ -59,12 +66,14 @@ class RootCommand(click.MultiCommand):
 class PluginCommand(click.MultiCommand):
     """Provides ActionCommands based on available Actions"""
     def __init__(self, plugin, *args, **kwargs):
+        import q2cli.util
+
         super().__init__(*args, **kwargs)
         # the cli currently doesn't differentiate between methods
         # and visualizers, it treats them generically as Actions
         self._plugin = plugin
-        self._action_lookup = {q2cli.util.to_cli_name(k): v for k, v in
-                               plugin.actions.items()}
+        self._action_lookup = {q2cli.util.to_cli_name(id): a for id, a in
+                               plugin['actions'].items()}
 
     def list_commands(self, ctx):
         return sorted(self._action_lookup)
@@ -74,7 +83,7 @@ class PluginCommand(click.MultiCommand):
             action = self._action_lookup[name]
         except KeyError:
             click.echo("Error: QIIME plugin %r has no action %r."
-                       % (self._plugin.name, name), err=True)
+                       % (self._plugin['name'], name), err=True)
             ctx.exit(2)  # Match exit code of `return None`
 
         return ActionCommand(name, self._plugin, action)
@@ -91,19 +100,26 @@ class ActionCommand(click.Command):
     can be used to supplement value lookup in the regular handlers.
     """
     def __init__(self, name, plugin, action):
+        import q2cli.handlers
+        import q2cli.util
+
+        self.plugin = plugin
         self.action = action
         self.generated_handlers = self.build_generated_handlers()
         # Meta-Handlers:
         self.output_dir_handler = q2cli.handlers.OutputDirHandler()
         self.cmd_config_handler = q2cli.handlers.CommandConfigHandler(
-            q2cli.util.to_cli_name(plugin.name),
-            q2cli.util.to_cli_name(self.action.id)
+            q2cli.util.to_cli_name(plugin['name']),
+            q2cli.util.to_cli_name(self.action['id'])
         )
         super().__init__(name, params=list(self.get_click_parameters()),
-                         callback=self, short_help=action.name,
-                         help=action.description)
+                         callback=self, short_help=action['name'],
+                         help=action['description'])
 
     def build_generated_handlers(self):
+        import operator
+        import q2cli.handlers
+
         handlers = collections.OrderedDict()
         handler_map = collections.OrderedDict([
             ('inputs', q2cli.handlers.ArtifactHandler),
@@ -111,16 +127,22 @@ class ActionCommand(click.Command):
             ('outputs', q2cli.handlers.ResultHandler)
         ])
 
+        signature = self.action['signature']
+        defaults = signature['defaults']
+
         for group_type, constructor in handler_map.items():
-            grp = getattr(self.action.signature, group_type)
+            grp = signature[group_type]
+
             # TODO Update order of inputs and parameters to match
             # `Action.signature` when signature retains API order:
-            # https://github.com/qiime2/qiime2/issues/70
-            # (i.e. just remove the sorted call)
-            defaults = self.action.signature.defaults
-            for name, (semtype, _) in sorted(grp.items(), key=lambda x: x[0]):
+            #
+            #     https://github.com/qiime2/qiime2/issues/70
+            #
+            # i.e. remove the `sorted` call below.
+            for item in sorted(grp, key=operator.itemgetter('name')):
+                name = item['name']
                 default = defaults.get(name, q2cli.handlers.NoDefault)
-                handlers[name] = constructor(name, semtype, default)
+                handlers[name] = constructor(default=default, **item)
 
         return handlers
 
@@ -135,6 +157,9 @@ class ActionCommand(click.Command):
 
     def __call__(self, **kwargs):
         """Called when user hits return, **kwargs are Dict[click_names, Obj]"""
+        import importlib
+        import itertools
+
         arguments, missing_in = self.handle_in_params(kwargs)
         outputs, missing_out = self.handle_out_params(kwargs)
 
@@ -151,22 +176,26 @@ class ActionCommand(click.Command):
                 click.echo(_OUTPUT_OPTION_ERR_MSG, err=True)
             ctx.exit(1)
 
-        results = self.action(**arguments)
-        if not isinstance(results, tuple):
-            results = results,
+        module_path = 'qiime.plugins.%s.actions' % self.plugin['id']
+        actions_module = importlib.import_module(module_path)
+        action = getattr(actions_module, self.action['id'])
+
+        results = action(**arguments)
 
         for result, output in zip(results, outputs):
-            if not output.endswith(result.extension):
-                output += result.extension
             result.save(output)
 
     def handle_in_params(self, kwargs):
+        import itertools
+        import q2cli.handlers
+
         arguments = {}
         missing = []
         cmd_fallback = self.cmd_config_handler.get_value(kwargs)
 
-        for name in itertools.chain(self.action.signature.inputs,
-                                    self.action.signature.parameters):
+        for item in itertools.chain(self.action['signature']['inputs'],
+                                    self.action['signature']['parameters']):
+            name = item['name']
             handler = self.generated_handlers[name]
             try:
                 arguments[name] = handler.get_value(
@@ -178,6 +207,8 @@ class ActionCommand(click.Command):
         return arguments, missing
 
     def handle_out_params(self, kwargs):
+        import q2cli.handlers
+
         outputs = []
         missing = []
         cmd_fallback = self.cmd_config_handler.get_value(kwargs)
@@ -191,7 +222,8 @@ class ActionCommand(click.Command):
             except q2cli.handlers.ValueNotFoundException:
                 return out_fallback(*args)
 
-        for name in self.action.signature.outputs:
+        for item in self.action['signature']['outputs']:
+            name = item['name']
             handler = self.generated_handlers[name]
 
             try:

--- a/q2cli/dev.py
+++ b/q2cli/dev.py
@@ -1,0 +1,55 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import click
+
+
+@click.group(help='Utilities for developers and advanced users.')
+def dev():
+    pass
+
+
+@dev.command(name='plugin-init',
+             short_help='Initialize plugin package from template.',
+             help="Initializes plugin package from template to specified"
+                  " output directory. Use this command if you are a"
+                  " plugin developer starting to develop a new plugin.")
+@click.pass_context
+@click.option('--output-dir', required=False,
+              type=click.Path(exists=False, file_okay=False, dir_okay=True,
+                              writable=True),
+              help='Directory in which to create plugin package.',
+              default='.')
+def plugin_init(ctx, output_dir):
+    import qiime.plugin
+
+    try:
+        path = qiime.plugin.plugin_init(output_dir=output_dir)
+    except FileExistsError as e:
+        click.secho("Plugin package directory name already exists under %s"
+                    % (output_dir if output_dir != '.' else
+                       'the current directory'),
+                    err=True, fg='red')
+        click.secho("Original error message:\n%s" % e, err=True, fg='red')
+        ctx.exit(1)
+    click.secho("Your plugin package has been created at %s" % path,
+                fg='green')
+
+
+@dev.command(name='refresh-cache',
+             short_help='Refresh CLI cache.',
+             help="Refresh the CLI cache. Use this command if you are "
+                  "developing a plugin, or q2cli itself, and want your "
+                  "changes to take effect in the CLI. A refresh of the cache "
+                  "is necessary because package versions do not typically "
+                  "change each time an update is made to a package's code. "
+                  "Setting the environment variable Q2CLIDEV to any value "
+                  "will always refresh the cache when a command is run.")
+def refresh_cache():
+    import q2cli.cache
+    q2cli.cache.CACHE.refresh()

--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -247,15 +247,15 @@ class MetadataCategoryHandler(Handler):
     def get_click_options(self):
         import click
 
+        md_name = '--' + self.cli_names[0]
         md_help = 'Metadata mapping file'
         md_kwargs = {
-            'name': ['--' + self.cli_names[0]],
             'type': click.Path(exists=True, dir_okay=False)
         }
 
+        mdc_name = '--' + self.cli_names[1]
         mdc_help = 'Category from metadata mapping file'
         mdc_kwargs = {
-            'name': ['--' + self.cli_names[1]],
             'type': str
         }
 
@@ -271,8 +271,8 @@ class MetadataCategoryHandler(Handler):
             md_kwargs['help'] = '%s  [required]' % md_help
             mdc_kwargs['help'] = '%s  [required]' % mdc_help
 
-        yield click.Option(**md_kwargs)
-        yield click.Option(**mdc_kwargs)
+        yield click.Option([md_name], **md_kwargs)
+        yield click.Option([mdc_name], **mdc_kwargs)
 
     def get_value(self, arguments, fallback=None):
         import qiime

--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -5,15 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
-import os
+
 import collections
-import configparser
-import warnings
-
-import click
-import qiime
-
-import q2cli.util
 
 # TODO: revisit how default values are handled when optional artifacts are
 # supported.
@@ -37,6 +30,8 @@ class Handler:
 
     @property
     def cli_name(self):
+        import q2cli.util
+
         # e.g. p-my-option-name
         return q2cli.util.to_cli_name(self.click_name)
 
@@ -86,12 +81,17 @@ class OutputDirHandler(Handler):
         super().__init__('output_dir')
 
     def get_click_options(self):
+        import click
+
         yield click.Option(
             ['--' + self.cli_name],
             type=click.Path(exists=False, dir_okay=True, file_okay=False),
             help='Output unspecified results to a directory')
 
     def get_value(self, arguments, fallback=None):
+        import os
+        import os.path
+
         try:
             path = self._locate_value(arguments, fallback=fallback)
             # TODO: do we want a --force like flag?
@@ -118,6 +118,8 @@ class CommandConfigHandler(Handler):
         super().__init__('cmd_config')
 
     def get_click_options(self):
+        import click
+
         yield click.Option(
             ['--' + self.cli_name],
             type=click.Path(exists=True, dir_okay=False, file_okay=True,
@@ -125,6 +127,9 @@ class CommandConfigHandler(Handler):
             help='Use config file for command options')
 
     def get_value(self, arguments, fallback=None):
+        import configparser
+        import warnings
+
         try:
             path = self._locate_value(arguments, fallback=fallback)
             config = configparser.ConfigParser()
@@ -156,23 +161,25 @@ class CommandConfigHandler(Handler):
 
 
 class GeneratedHandler(Handler):
-    def __init__(self, name, semtype, default=NoDefault):
+    def __init__(self, name, repr, default=NoDefault):
         super().__init__(name, prefix=self.prefix, default=default)
-        self.semtype = semtype
-        self.ast = semtype.to_ast()
+        self.repr = repr
 
 
 class ArtifactHandler(GeneratedHandler):
     prefix = 'i_'
 
     def get_click_options(self):
+        import click
+
         yield click.Option(['--' + self.cli_name],
                            type=click.Path(exists=False, dir_okay=False),
-                           help="Artifact: %r  [required]" % self.semtype)
+                           help="Artifact: %s  [required]" % self.repr)
 
     def get_value(self, arguments, fallback=None):
-        path = self._locate_value(arguments, fallback)
+        import qiime
 
+        path = self._locate_value(arguments, fallback)
         return qiime.Artifact.load(path)
 
 
@@ -180,23 +187,24 @@ class ResultHandler(GeneratedHandler):
     prefix = 'o_'
 
     def get_click_options(self):
+        import click
+
         yield click.Option(['--' + self.cli_name],
                            type=click.Path(exists=False, dir_okay=False),
-                           help="Artifact: %r  [required if not passing "
-                                "--output-dir]" % self.semtype)
+                           help="Artifact: %s  [required if not passing "
+                                "--output-dir]" % self.repr)
 
     def get_value(self, arguments, fallback=None):
         return self._locate_value(arguments, fallback)
 
 
-def parameter_handler_factory(name, semtype, default=NoDefault):
-    ast = semtype.to_ast()
+def parameter_handler_factory(name, repr, ast, default=NoDefault):
     if ast['name'] == 'Metadata':
         return MetadataHandler(name, default=default)
     elif ast['name'] == 'MetadataCategory':
         return MetadataCategoryHandler(name, default=default)
     else:
-        return RegularParameterHandler(name, semtype, default=default)
+        return RegularParameterHandler(name, repr, ast, default=default)
 
 
 class MetadataHandler(Handler):
@@ -205,6 +213,8 @@ class MetadataHandler(Handler):
         self.click_name += '_file'
 
     def get_click_options(self):
+        import click
+
         name = '--' + self.cli_name
         type = click.Path(exists=True, dir_okay=False)
         help = 'Metadata mapping file'
@@ -218,12 +228,16 @@ class MetadataHandler(Handler):
             yield click.Option([name], type=type, help='%s  [required]' % help)
 
     def get_value(self, arguments, fallback=None):
+        import qiime
+
         path = self._locate_value(arguments, fallback)
         return qiime.Metadata.load(path)
 
 
 class MetadataCategoryHandler(Handler):
     def __init__(self, name, default=NoDefault):
+        import q2cli.util
+
         super().__init__(name, prefix='m_', default=default)
         self.name = name
         self.click_names = ['m_%s_file' % name, 'm_%s_category' % name]
@@ -231,6 +245,8 @@ class MetadataCategoryHandler(Handler):
             q2cli.util.to_cli_name(n) for n in self.click_names]
 
     def get_click_options(self):
+        import click
+
         md_help = 'Metadata mapping file'
         md_kwargs = {
             'name': ['--' + self.cli_names[0]],
@@ -239,7 +255,7 @@ class MetadataCategoryHandler(Handler):
 
         mdc_help = 'Category from metadata mapping file'
         mdc_kwargs = {
-            'name': '--' + self.cli_names[1],
+            'name': ['--' + self.cli_names[1]],
             'type': str
         }
 
@@ -259,6 +275,8 @@ class MetadataCategoryHandler(Handler):
         yield click.Option(**mdc_kwargs)
 
     def get_value(self, arguments, fallback=None):
+        import qiime
+
         values = []
         failed = False
         # This is nastier looking than it really is.
@@ -282,7 +300,13 @@ class MetadataCategoryHandler(Handler):
 class RegularParameterHandler(GeneratedHandler):
     prefix = 'p_'
 
+    def __init__(self, name, repr, ast, default=NoDefault):
+        super().__init__(name, repr, default=default)
+        self.ast = ast
+
     def get_type(self):
+        import click
+
         mapping = {
             'Int': int,
             'Str': str,
@@ -300,6 +324,9 @@ class RegularParameterHandler(GeneratedHandler):
         return mapping[self.ast['name']]
 
     def get_click_options(self):
+        import click
+        import q2cli.util
+
         type = self.get_type()  # Use the ugly lookup above
         if type is bool:
             no_name = self.prefix + 'no_' + self.name
@@ -324,4 +351,6 @@ class RegularParameterHandler(GeneratedHandler):
         elif self.get_type() is bool:
             return value
         else:
-            return self.semtype.decode(value)
+            import qiime.sdk
+            return qiime.sdk.parse_type(
+                self.repr, expect='primitive').decode(value)

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -37,9 +37,11 @@ class CliTests(unittest.TestCase):
     def test_info(self):
         result = self.runner.invoke(info)
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue(result.output.startswith('System versions'))
-        self.assertTrue('Installed plugins' in result.output)
-        self.assertTrue('dummy-plugin' in result.output)
+        # May not always start with "System versions" if cache updating message
+        # is printed.
+        self.assertIn('System versions', result.output)
+        self.assertIn('Installed plugins', result.output)
+        self.assertIn('dummy-plugin', result.output)
 
     def test_list_commands(self):
         # top level commands, including a plugin, are present

--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -7,5 +7,10 @@
 # ----------------------------------------------------------------------------
 
 
+def get_app_dir():
+    import click
+    return click.get_app_dir('q2cli', roaming=False)
+
+
 def to_cli_name(name):
     return name.replace('_', '-')


### PR DESCRIPTION
Previously, any CLI command would take ~3 seconds (tested with q2-types, q2-feature-table, q2-diversity, q2-emperor installed). The CLI was virtually unusable and tab-completion (as provided out of the box by Click) was even more unusable. This poor performance would have scaled with the number of installed plugins.

Now, the CLI caches its state to a system-specific config directory. The cache is automatically refreshed when a change is made to the current QIIME deployment (e.g. a plugin is uninstalled, a new plugin is installed, a plugin version changes, or the version of q2cli changes).

There are two mechanisms (mainly for developers) to force a cache refresh: the `qiime dev refresh-cache` command, or setting the Q2CLIDEV environment variable to any value. Devs will need to use one of these options to see changes in their plugins (or q2cli itself) reflected in the CLI. Users should not have to force a refresh.

Most commands that don't do any real work take ~420ms to complete, resulting in a ~7x speedup. The performance will have negligible degradation as the number of installed plugins increases. Commands that do real work are faster than before but not benchmarked as their runtimes depend on the specific method being run, and the speedup is less likely to be noticed by users. What's important here is having a snappy CLI while users are exploring its functionality, e.g. requesting help text, running "info" types of commands, etc.

Further optimization is of course possible, and it would be ideal to get the runtime below ~420ms. The speedups here seem to justify closing #63 as the CLI is in a much more usable state now.

Fixes #63.