### PR TITLE
ENH: faster `qiime --version` flag with shorter output

### DIFF
--- a/q2cli/__main__.py
+++ b/q2cli/__main__.py
@@ -9,14 +9,14 @@
 import click
 
 import q2cli.commands
-import q2cli.info
 
 
 # Entry point for CLI
 @click.command(cls=q2cli.commands.RootCommand, invoke_without_command=True,
                no_args_is_help=True)
-@click.option('--version', is_flag=True, callback=q2cli.info.echo_version,
-              help='Print the version and exit.', expose_value=False)
+@click.version_option(prog_name='q2cli',
+                      message='%(prog)s version %(version)s\nRun `qiime info` '
+                              'for more version details.')
 def cli():
     pass
 

--- a/q2cli/info.py
+++ b/q2cli/info.py
@@ -9,19 +9,16 @@
 import click
 
 
-def echo_version(ctx=None, name=None, value=True):
-    if value:
-        # Conditional imports because this callback appears to be invoked when
-        # any command is run (in most cases, `value` is `False`).
-        import sys
-        import qiime
-        import q2cli
+def _echo_version():
+    import sys
+    import qiime
+    import q2cli
 
-        pyver = sys.version_info
-        click.echo('Python version: %d.%d.%d' %
-                   (pyver.major, pyver.minor, pyver.micro))
-        click.echo('QIIME version: %s' % qiime.__version__)
-        click.echo('q2cli version: %s' % q2cli.__version__)
+    pyver = sys.version_info
+    click.echo('Python version: %d.%d.%d' %
+               (pyver.major, pyver.minor, pyver.micro))
+    click.echo('QIIME version: %s' % qiime.__version__)
+    click.echo('q2cli version: %s' % q2cli.__version__)
 
 
 def _echo_plugins():
@@ -59,7 +56,7 @@ def info(py_packages):
     import q2cli.cache
 
     click.secho('System versions', fg='green')
-    echo_version()
+    _echo_version()
     click.secho('\nInstalled plugins', fg='green')
     _echo_plugins()
     if py_packages:


### PR DESCRIPTION
Example:

```shell
$ qiime --version
q2cli version 0.0.3
Run `qiime info` for more version details.
```

Fixes #68.