### PR TITLE
BUG: fixes broken boolean flag handler

### DIFF
--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -332,17 +332,22 @@ class RegularParameterHandler(GeneratedHandler):
             no_name = self.prefix + 'no_' + self.name
             cli_no_name = q2cli.util.to_cli_name(no_name)
             name = '--' + self.cli_name + '/--' + cli_no_name
+            # click.Option type is determined implicitly for flags with
+            # secondary options, and explicitly passing type=bool results in a
+            # TypeError, so we pass type=None (the default).
+            option_type = None
         else:
             name = '--' + self.cli_name
+            option_type = type
 
         if self.default is NoDefault:
-            yield click.Option([name], type=type, help='[required]')
+            yield click.Option([name], type=option_type, help='[required]')
         elif self.default is None:
-            yield click.Option([name], type=type, default=self.default,
-                               help='[optional]')
+            yield click.Option([name], default=self.default,
+                               type=option_type, help='[optional]')
         else:
-            yield click.Option([name], type=type, default=self.default,
-                               show_default=True)
+            yield click.Option([name], default=self.default,
+                               type=option_type, show_default=True)
 
     def get_value(self, arguments, fallback=None):
         value = self._locate_value(arguments, fallback)


### PR DESCRIPTION
Processing of boolean flags was broken in master. I discovered this by running ``qiime dada2 denoise`` and getting the following:

```
raise TypeError('Got secondary option for non boolean flag.')
```

The [docs](http://click.pocoo.org/5/options/#boolean-flags) don't set `type` when creating boolean flags with secondary options (i.e., ``--something/--no-something``), so I followed that example.  