### PR TITLE
ENH/BUG: add --verbose flag; fix two --cmd-config bugs

### DIFF
--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -87,9 +87,14 @@ class CliTests(unittest.TestCase):
         left_path = os.path.join(self.tempdir, 'left.qza')
         right_path = os.path.join(self.tempdir, 'right.qza')
 
+        # TODO: currently must pass `--verbose` to commands invoked by Click's
+        # test runner because redirecting stdout/stderr raises an
+        # "io.UnsupportedOperation: fileno" error. Likely related to Click
+        # mocking a filesystem in the test runner.
         result = self.runner.invoke(
             command, ['split-ints', '--i-ints', self.artifact1_path,
-                      '--o-left', left_path, '--o-right', right_path])
+                      '--o-left', left_path, '--o-right', right_path,
+                      '--verbose'])
         # command completes successfully and creates the correct
         # output files
         self.assertEqual(result.exit_code, 0)
@@ -113,7 +118,8 @@ class CliTests(unittest.TestCase):
 
         result = self.runner.invoke(
             command, ['split-ints', '--i-ints', self.artifact1_path,
-                      '--o-left', left_path, '--o-right', right_path])
+                      '--o-left', left_path, '--o-right', right_path,
+                      '--verbose'])
         # command completes successfully and creates the correct
         # output files
         self.assertEqual(result.exit_code, 0)
@@ -134,7 +140,7 @@ class CliTests(unittest.TestCase):
 
         result = self.runner.invoke(
             command, ['most-common-viz', '--i-ints', self.artifact1_path,
-                      '--o-visualization', viz_path])
+                      '--o-visualization', viz_path, '--verbose'])
         # command completes successfully and creates the correct
         # output file
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
Adds a `--verbose` flag to plugin action commands (off by default) that displays any stdout/stderr generated by an action.

Also fixed two bugs in --cmd-config option:

- supplying a value in config was ignored if the option had a default value
- boolean flags in config did not work correctly; any value was evaluated as true except for the empty value, and the value (as a `str`) was forwarded to the action instead of being converted to a `bool` type.

Also improved error message for when `--output-dir` directory already exists (previously was a traceback, now is a nicely formatted Click echo).

Fixes #64.