### PR TITLE
ENH: support optional metadata on command line

### DIFF
--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -294,7 +294,10 @@ class MetadataHandler(Handler):
         import qiime
 
         path = self._locate_value(arguments, fallback)
-        return qiime.Metadata.load(path)
+        if path is None:
+            return None
+        else:
+            return qiime.Metadata.load(path)
 
 
 class MetadataCategoryHandler(Handler):
@@ -353,8 +356,10 @@ class MetadataCategoryHandler(Handler):
 
         if failed:
             raise ValueNotFoundException()
-
-        return qiime.MetadataCategory.load(*values)
+        if values == [None, None]:
+            return None
+        else:
+            return qiime.MetadataCategory.load(*values)
 
 
 class RegularParameterHandler(GeneratedHandler):


### PR DESCRIPTION
Before this change, the handler would try to load the `qiime.Metadata` object passing `path=None`. 

@ebolyen, @jairideout does this fix look right to you? I'm not too familiar with this code, but it's now handled essentially the same way as in `RegularParameterHandler`, and the command below now works. 

```bash
$ qiime feature-table filter-samples --i-table table.qza --o-filtered-table junk --p-min-frequency 2000 --p-max-frequency 4000
Traceback (most recent call last):
  File "/Users/caporaso/Google Drive/code/qiime2/qiime2/qiime/metadata.py", line 25, in load
    df = pd.read_csv(path, sep='\t', dtype=object)
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/pandas/io/parsers.py", line 562, in parser_f
    return _read(filepath_or_buffer, kwds)
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/pandas/io/parsers.py", line 315, in _read
    parser = TextFileReader(filepath_or_buffer, **kwds)
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/pandas/io/parsers.py", line 645, in __init__
    self._make_engine(self.engine)
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/pandas/io/parsers.py", line 799, in _make_engine
    self._engine = CParserWrapper(self.f, **self.options)
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/pandas/io/parsers.py", line 1213, in __init__
    self._reader = _parser.TextReader(src, **kwds)
  File "pandas/parser.pyx", line 358, in pandas.parser.TextReader.__cinit__ (pandas/parser.c:3427)
  File "pandas/parser.pyx", line 645, in pandas.parser.TextReader._setup_parser_source (pandas/parser.c:7038)
OSError: Expected file path name or file-like object, got <class 'NoneType'> type

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/bin/qiime", line 11, in <module>
    load_entry_point('q2cli', 'console_scripts', 'qiime')()
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/caporaso/miniconda3/envs/qiime2-dev/lib/python3.5/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/caporaso/Google Drive/code/qiime2/q2cli/q2cli/commands.py", line 181, in __call__
    arguments, missing_in, verbose = self.handle_in_params(kwargs)
  File "/Users/caporaso/Google Drive/code/qiime2/q2cli/q2cli/commands.py", line 231, in handle_in_params
    kwargs, fallback=cmd_fallback
  File "/Users/caporaso/Google Drive/code/qiime2/q2cli/q2cli/handlers.py", line 297, in get_value
    return qiime.Metadata.load(path)
  File "/Users/caporaso/Google Drive/code/qiime2/qiime2/qiime/metadata.py", line 30, in load
    "due to incompatible file permissions)." % path)
OSError: Metadata file None doesn't exist or isn't accessible (e.g., due to incompatible file permissions).
```