### PR TITLE
ENH: Add support for ZSH tab-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,22 @@ A [click-based](http://click.pocoo.org/) command line interface for [QIIME 2](ht
 
 Visit https://qiime2.org to learn more about q2cli and the QIIME 2 project.
 
-## Enabling Bash tab completion
+## Enabling tab completion
+
+### Bash
 
 To enable tab completion in Bash, run the following command or add it to your `.bashrc`/`.bash_profile`:
 
 ```bash
+source tab-qiime
+```
+
+### ZSH
+
+To enable tab completion in ZSH, run the following commands or add them to your `.zshrc`:
+
+```bash
+autoload bashcompinit
+bashcompinit
 source tab-qiime
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,5 @@ source tab-qiime
 To enable tab completion in ZSH, run the following commands or add them to your `.zshrc`:
 
 ```bash
-autoload bashcompinit
-bashcompinit
-source tab-qiime
+autoload bashcompinit && bashcompinit && source tab-qiime
 ```

--- a/bin/tab-qiime
+++ b/bin/tab-qiime
@@ -13,7 +13,7 @@ _qiime_completion()
 {
   # Attempt to find the cached completion script. If q2cli isn't installed, or
   # is an incompatible version, don't attempt completion.
-  local qpath="$(python -c "import q2cli.util; print(q2cli.util.get_completion_path())" 2> /dev/null)"
+  local completion_path="$(python -c "import q2cli.util; print(q2cli.util.get_completion_path())" 2> /dev/null)"
 
   if [[ $? != 0 ]]; then
     unset COMPREPLY
@@ -24,8 +24,8 @@ _qiime_completion()
   # in a subshell, supplying COMP_WORDS and COMP_CWORD. Capture the output as
   # the completion reply. If the completion script failed, don't attempt
   # completion.
-  if [[ -f "$qpath" ]] ; then
-    COMPREPLY=( $(COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD="${COMP_CWORD}" "$qpath" 2> /dev/null) )
+  if [[ -f "$completion_path" ]] ; then
+    COMPREPLY=( $(COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD="${COMP_CWORD}" "$completion_path" 2> /dev/null) )
 
     if [[ $? != 0 ]]; then
       unset COMPREPLY

--- a/bin/tab-qiime
+++ b/bin/tab-qiime
@@ -13,7 +13,7 @@ _qiime_completion()
 {
   # Attempt to find the cached completion script. If q2cli isn't installed, or
   # is an incompatible version, don't attempt completion.
-  local path="$(python -c "import q2cli.util; print(q2cli.util.get_completion_path())" 2> /dev/null)"
+  local qpath="$(python -c "import q2cli.util; print(q2cli.util.get_completion_path())" 2> /dev/null)"
 
   if [[ $? != 0 ]]; then
     unset COMPREPLY
@@ -24,8 +24,8 @@ _qiime_completion()
   # in a subshell, supplying COMP_WORDS and COMP_CWORD. Capture the output as
   # the completion reply. If the completion script failed, don't attempt
   # completion.
-  if [[ -f "$path" ]] ; then
-    COMPREPLY=( $(COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD="${COMP_CWORD}" "$path" 2> /dev/null) )
+  if [[ -f "$qpath" ]] ; then
+    COMPREPLY=( $(COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD="${COMP_CWORD}" "$qpath" 2> /dev/null) )
 
     if [[ $? != 0 ]]; then
       unset COMPREPLY

--- a/q2cli/__main__.py
+++ b/q2cli/__main__.py
@@ -25,9 +25,7 @@ To enable tab completion in Bash, run the following command or add it to your \
 To enable tab completion in ZSH, run the following commands or add them to \
 your .zshrc:
 
-    autoload bashcompinit
-    bashcompinit
-    source tab-qiime
+    autoload bashcompinit && bashcompinit && source tab-qiime
 
 """
 

--- a/q2cli/__main__.py
+++ b/q2cli/__main__.py
@@ -22,6 +22,13 @@ To enable tab completion in Bash, run the following command or add it to your \
 
     source tab-qiime
 
+To enable tab completion in ZSH, run the following commands or add them to \
+your .zshrc:
+
+    autoload bashcompinit
+    bashcompinit
+    source tab-qiime
+
 """
 
 


### PR DESCRIPTION
Fixes #91 

Note: apparently `path` was overwriting the shell variable `$PATH` in ZSH, which was why this wasn't working previously.