### PR TITLE
BUG: Fix `qiime tools peek` for visualizations

### DIFF
--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -76,8 +76,9 @@ def peek(path):
     click.secho(metadata.uuid)
     click.secho("Type:        ", fg="green", nl=False)
     click.secho(metadata.type)
-    click.secho("Data format: ", fg="green", nl=False)
-    click.secho(metadata.format)
+    if metadata.format is not None:
+        click.secho("Data format: ", fg="green", nl=False)
+        click.secho(metadata.format)
 
 
 @tools.command(short_help='View a QIIME Visualization.',


### PR DESCRIPTION
Visualizations have a `format` of `None` which did not work with
`click.secho`. The "Data format:" section of the output is now omitted
for visualizations as it is not relevant.

Fixes #101 