### PR TITLE
ENH: Disallow viewing on headless environments.

### DIFF
--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -97,7 +97,7 @@ def view(visualization_path, index_extension):
             'Visualization viewing is currently not supported in headless '
             'environments. You can view Visualizations (and Artifacts) at '
             'https://view.qiime2.org, or move the Visualization to an '
-            'environment with a display and view it with qiime tools view.')
+            'environment with a display and view it with `qiime tools view`.')
 
     import zipfile
     import qiime.sdk

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -91,6 +91,14 @@ def peek(path):
               help='The extension of the index file that should be opened. '
                    '[default: html]')
 def view(visualization_path, index_extension):
+    # Guard headless envs from having to import anything
+    if not os.getenv("DISPLAY"):
+        raise click.UsageError(
+            'Visualization viewing is currently not supported on headless '
+            'environments. You can provide a public path to your file at '
+            'https://view.qiime2.org, or move the Visualization to your '
+            'local machine and view it through qiime tools view.')
+
     import zipfile
     import qiime.sdk
 

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -94,10 +94,10 @@ def view(visualization_path, index_extension):
     # Guard headless envs from having to import anything
     if not os.getenv("DISPLAY"):
         raise click.UsageError(
-            'Visualization viewing is currently not supported on headless '
-            'environments. You can provide a public path to your file at '
-            'https://view.qiime2.org, or move the Visualization to your '
-            'local machine and view it through qiime tools view.')
+            'Visualization viewing is currently not supported in headless '
+            'environments. You can view Visualizations (and Artifacts) at '
+            'https://view.qiime2.org, or move the Visualization to an '
+            'environment with a display and view it with qiime tools view.')
 
     import zipfile
     import qiime.sdk


### PR DESCRIPTION
Previously `qiime tools view` would "work" and just not alert the user that it won't actually work in a headless environment.

Resolves #103 

*Question*
Wasn't entirely sure on how to word the message, does it sound ok, or need tweaks?

Test run

```
(qiime)jakereps@bacon:~$ qiime tools view blah.txt
Usage: qiime tools view [OPTIONS] VISUALIZATION_PATH

Error: Visualization viewing is currently not supported on headless environments. You can provide a public path to your file at https://view.qiime2.org, or move the Visualization to your local machine and view it through qiime tools view.
(qiime)jakereps@bacon:~$ 
```