### PR TITLE
ENH: Validate proper input characters

### DIFF
--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -24,6 +24,18 @@ class RootCommand(click.MultiCommand):
     ])
 
     def __init__(self, *args, **kwargs):
+        import sys
+        invalid = []
+        unicodes = ["\u2018", "\u2019", "\u201C", "\u201D", "\u2014"]
+        for command in sys.argv:
+            if any(x in command for x in unicodes):
+                invalid.append(command)
+        if invalid:
+            click.secho("Error: Detected invalid character in: %s\n"
+                        "Verify the correct quotes or dashes (ASCII) are "
+                        "being used." %
+                        ', '.join(invalid), err=True, fg='red', bold=True)
+            sys.exit(-1)
         super().__init__(*args, **kwargs)
 
         # Plugin state for current deployment that will be loaded from cache.


### PR DESCRIPTION
Catches and warns of potentially invalid characters that can occur from code being placed in a text editor that tries too hard.

```bash
(qiime2) [16:42] q2cli (emdash) $ qiime —version
Error: Detected invalid character in: —version
Verify the correct quotes or dashes (ASCII) are being used.
(qiime2) [16:42] q2cli (emdash) $ qiime test-plugin blocking-test --i-table ~/Documents/qiime2-moving-pictures-tutorial/table.qza --o-rarefied-table blah —p-timeout 5
Error: Detected invalid character in: —p-timeout
Verify the correct quotes or dashes (ASCII) are being used.
```

Resolves #107