### PR TITLE
ENH: Add feedback to result saving

### DIFF
--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -215,7 +215,8 @@ class ActionCommand(click.Command):
             results = action(**arguments)
 
         for result, output in zip(results, outputs):
-            result.save(output)
+            click.echo('Saved to: %s' % result.save(output))
+
 
     def handle_in_params(self, kwargs):
         import itertools

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -215,8 +215,8 @@ class ActionCommand(click.Command):
             results = action(**arguments)
 
         for result, output in zip(results, outputs):
-            click.echo('Saved to: %s' % result.save(output))
-
+            click.secho('Saved %s to: %s' % (result.type,
+                                             result.save(output)), fg='green')
 
     def handle_in_params(self, kwargs):
         import itertools


### PR DESCRIPTION
Resolves #98 

Thoughts on verbiage? `Saved to:` `Written to:` `<filepath only>`. Extend the filepath beyond the relative path that is returned by `.save()`?

```
(qiime2) [17:09] qiime2-moving-pictures-tutorial $ qiime diversity beta-group-significance --i-distance-matrix cm1441/unweighted_unifrac_distance_matrix.qza --m-metadata-file sample-metadata.tsv --m-metadata-category BodySite --o-visualization cm1441/unweighted-unifrac-body-site-significance
Saved to: cm1441/unweighted-unifrac-body-site-significance.qzv
(qiime2) [17:09] qiime2-moving-pictures-tutorial $ 
```