### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -n test-env python=$PYTHON_VERSION nose flake8
+  - conda create --yes -n test-env python=$PYTHON_VERSION nose
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip
+  # pip has a much newer version of flake8 than conda.
+  - pip install flake8
   - pip install .
 script:
   - QIIMETEST= nosetests
-  - flake8 q2cli setup.py
+  - flake8
   - source tab-qiime

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,11 @@ install:
   - conda create --yes -n test-env python=$PYTHON_VERSION nose
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip
-  # pip has a much newer version of flake8 than conda.
   - pip install flake8
   - pip install .
+  - git clone https://github.com/qiime2/q2lint
 script:
   - QIIMETEST= nosetests
   - flake8
+  - python q2lint/q2lint.py
   - source tab-qiime

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, QIIME 2 Development Team
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of q2cli nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/q2cli/__init__.py
+++ b/q2cli/__init__.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 import pkg_resources

--- a/q2cli/__init__.py
+++ b/q2cli/__init__.py
@@ -6,4 +6,6 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-__version__ = '0.0.7.dev0'
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution('q2cli').version

--- a/q2cli/__main__.py
+++ b/q2cli/__main__.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 import click

--- a/q2cli/cache.py
+++ b/q2cli/cache.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 

--- a/q2cli/cache.py
+++ b/q2cli/cache.py
@@ -144,17 +144,17 @@ class DeploymentCache:
         # cache is outdated.
         #
         # TODO: this code is copied from
-        # `qiime.sdk.PluginManager.iter_entry_points`. Importing QIIME is
+        # `qiime2.sdk.PluginManager.iter_entry_points`. Importing QIIME is
         # currently slow, and it adds ~600-700ms to any CLI command. This makes
         # the CLI pretty unresponsive, especially when running help/informative
         # commands. Uncomment the following lines when
         # https://github.com/qiime2/qiime2/issues/151 is fixed:
         #
-        # for ep in qiime.sdk.PluginManager.iter_entry_points():
+        # for ep in qiime2.sdk.PluginManager.iter_entry_points():
         #     reqs.add(ep.dist.as_requirement())
         #
         for entry_point in pkg_resources.iter_entry_points(
-                group='qiime.plugins'):
+                group='qiime2.plugins'):
             if entry_point.name != 'dummy-plugin' or 'QIIMETEST' in os.environ:
                 reqs.add(entry_point.dist.as_requirement())
 
@@ -220,13 +220,13 @@ class DeploymentCache:
         cache needs to be refreshed.
 
         """
-        import qiime.sdk
+        import qiime2.sdk
 
         state = {
             'plugins': {}
         }
 
-        plugin_manager = qiime.sdk.PluginManager()
+        plugin_manager = qiime2.sdk.PluginManager()
         for name, plugin in plugin_manager.plugins.items():
             state['plugins'][name] = self._get_plugin_state(plugin)
 
@@ -235,7 +235,7 @@ class DeploymentCache:
     def _get_plugin_state(self, plugin):
         state = {
             # TODO this conversion also happens in the framework
-            # (qiime/plugins.py) to generate an importable module name from a
+            # (qiime2/plugins.py) to generate an importable module name from a
             # plugin's `.name` attribute. Centralize this knowledge in the
             # framework, ideally as a machine-friendly plugin ID (similar to
             # `Action.id`).

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 import collections

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -107,7 +107,7 @@ class PluginCommand(click.MultiCommand):
         try:
             action = self._action_lookup[name]
         except KeyError:
-            click.echo("Error: QIIME plugin %r has no action %r."
+            click.echo("Error: QIIME 2 plugin %r has no action %r."
                        % (self._plugin['name'], name), err=True)
             ctx.exit(2)  # Match exit code of `return None`
 
@@ -115,7 +115,7 @@ class PluginCommand(click.MultiCommand):
 
 
 class ActionCommand(click.Command):
-    """A click manifestation of a QIIME API Action (Method/Visualizer)
+    """A click manifestation of a QIIME 2 API Action (Method/Visualizer)
 
     The ActionCommand generates Handlers which map from 1 Action API parameter
     to one or more Click.Options.
@@ -181,7 +181,7 @@ class ActionCommand(click.Command):
         import importlib
         import itertools
         import os
-        import qiime.util
+        import qiime2.util
 
         arguments, missing_in, verbose = self.handle_in_params(kwargs)
         outputs, missing_out = self.handle_out_params(kwargs)
@@ -199,19 +199,19 @@ class ActionCommand(click.Command):
                 click.echo(_OUTPUT_OPTION_ERR_MSG, err=True)
             ctx.exit(1)
 
-        module_path = 'qiime.plugins.%s.actions' % self.plugin['id']
+        module_path = 'qiime2.plugins.%s.actions' % self.plugin['id']
         actions_module = importlib.import_module(module_path)
         action = getattr(actions_module, self.action['id'])
 
         stdout = os.devnull
         stderr = os.devnull
         if verbose:
-            # `qiime.util.redirected_stdio` defaults to stdout/stderr when
+            # `qiime2.util.redirected_stdio` defaults to stdout/stderr when
             # supplied `None`.
             stdout = None
             stderr = None
 
-        with qiime.util.redirected_stdio(stdout=stdout, stderr=stderr):
+        with qiime2.util.redirected_stdio(stdout=stdout, stderr=stderr):
             results = action(**arguments)
 
         for result, output in zip(results, outputs):

--- a/q2cli/completion.py
+++ b/q2cli/completion.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 

--- a/q2cli/dev.py
+++ b/q2cli/dev.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 import click

--- a/q2cli/dev.py
+++ b/q2cli/dev.py
@@ -26,10 +26,10 @@ def dev():
               help='Directory in which to create plugin package.',
               default='.')
 def plugin_init(ctx, output_dir):
-    import qiime.plugin
+    import qiime2.plugin
 
     try:
-        path = qiime.plugin.plugin_init(output_dir=output_dir)
+        path = qiime2.plugin.plugin_init(output_dir=output_dir)
     except FileExistsError as e:
         click.secho("Plugin package directory name already exists under %s"
                     % (output_dir if output_dir != '.' else

--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 import collections

--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -241,10 +241,10 @@ class ArtifactHandler(GeneratedHandler):
                            help="Artifact: %s  [required]" % self.repr)
 
     def get_value(self, arguments, fallback=None):
-        import qiime
+        import qiime2
 
         path = self._locate_value(arguments, fallback)
-        return qiime.Artifact.load(path)
+        return qiime2.Artifact.load(path)
 
 
 class ResultHandler(GeneratedHandler):
@@ -291,13 +291,13 @@ class MetadataHandler(Handler):
             yield click.Option([name], type=type, help='%s  [required]' % help)
 
     def get_value(self, arguments, fallback=None):
-        import qiime
+        import qiime2
 
         path = self._locate_value(arguments, fallback)
         if path is None:
             return None
         else:
-            return qiime.Metadata.load(path)
+            return qiime2.Metadata.load(path)
 
 
 class MetadataCategoryHandler(Handler):
@@ -338,7 +338,7 @@ class MetadataCategoryHandler(Handler):
         yield click.Option([mdc_name], **mdc_kwargs)
 
     def get_value(self, arguments, fallback=None):
-        import qiime
+        import qiime2
 
         values = []
         failed = False
@@ -359,7 +359,7 @@ class MetadataCategoryHandler(Handler):
         if values == [None, None]:
             return None
         else:
-            return qiime.MetadataCategory.load(*values)
+            return qiime2.MetadataCategory.load(*values)
 
 
 class RegularParameterHandler(GeneratedHandler):
@@ -433,6 +433,6 @@ class RegularParameterHandler(GeneratedHandler):
                 value = self._parse_boolean(value)
             return value
         else:
-            import qiime.sdk
-            return qiime.sdk.parse_type(
+            import qiime2.sdk
+            return qiime2.sdk.parse_type(
                 self.repr, expect='primitive').decode(value)

--- a/q2cli/info.py
+++ b/q2cli/info.py
@@ -11,13 +11,13 @@ import click
 
 def _echo_version():
     import sys
-    import qiime
+    import qiime2
     import q2cli
 
     pyver = sys.version_info
     click.echo('Python version: %d.%d.%d' %
                (pyver.major, pyver.minor, pyver.micro))
-    click.echo('QIIME version: %s' % qiime.__version__)
+    click.echo('QIIME 2 version: %s' % qiime2.__version__)
     click.echo('q2cli version: %s' % q2cli.__version__)
 
 
@@ -65,7 +65,7 @@ def _echo_citations():
 
 @click.command(help='Display information about current deployment.')
 @click.option('--citations', is_flag=True,
-              help='Display citations for QIIME and installed plugins.')
+              help='Display citations for QIIME 2 and installed plugins.')
 @click.option('--py-packages', is_flag=True,
               help='Display names and versions of all installed Python '
                    'packages.')
@@ -92,10 +92,10 @@ def info(citations, py_packages):
                 'QIIME 2 and the plugins that you used. ', nl=False)
 
     if citations:
-        click.secho('The citations for QIIME and all installed plugins '
+        click.secho('The citations for QIIME 2 and all installed plugins '
                     'follow.')
         _echo_citations()
     else:
-        click.secho('To display the citations for QIIME and all installed '
+        click.secho('To display the citations for QIIME 2 and all installed '
                     'plugins, run:')
         click.secho('\n  qiime info --citations\n')

--- a/q2cli/info.py
+++ b/q2cli/info.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 import click

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -12,9 +12,9 @@ import tempfile
 import shutil
 
 from click.testing import CliRunner
-from qiime import Artifact, Visualization
-from qiime.core.testing.type import IntSequence1
-from qiime.core.archive import ImportProvenanceCapture
+from qiime2 import Artifact, Visualization
+from qiime2.core.testing.type import IntSequence1
+from qiime2.core.archive import ImportProvenanceCapture
 
 
 from q2cli.info import info

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 import os.path

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 import os

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -11,15 +11,15 @@ import os
 import click
 
 
-@click.group(help='Tools for working with QIIME files.')
+@click.group(help='Tools for working with QIIME 2 files.')
 def tools():
     pass
 
 
 @tools.command(name='export',
-               short_help='Export data from a QIIME Artifact or '
+               short_help='Export data from a QIIME 2 Artifact or '
                           'Visualization.',
-               help="Export data from a QIIME Artifact or Visualization. "
+               help="Export data from a QIIME 2 Artifact or Visualization. "
                     "Exporting extracts the data stored in an Artifact or "
                     "Visualization and will support exporting to multiple "
                     "formats in the future. For now, the data is exported in "
@@ -31,15 +31,15 @@ def tools():
               type=click.Path(exists=False, dir_okay=True),
               help='Directory where data should be exported to')
 def export_data(path, output_dir):
-    import qiime.sdk
+    import qiime2.sdk
 
-    result = qiime.sdk.Result.load(path)
+    result = qiime2.sdk.Result.load(path)
     result.export_data(output_dir)
 
 
 @tools.command(name='import',
-               short_help='Import data into a new QIIME Artifact.',
-               help="Import data to create a new QIIME Artifact. See "
+               short_help='Import data into a new QIIME 2 Artifact.',
+               help="Import data to create a new QIIME 2 Artifact. See "
                     "https://docs.qiime2.org/ for usage examples and details "
                     "on the file types and associated semantic types that can "
                     "be imported.")
@@ -56,21 +56,22 @@ def export_data(path, output_dir):
                    'data must be in the format expected by the semantic type '
                    'provided via --type.')
 def import_data(type, input_path, output_path, source_format=None):
-    import qiime.sdk
+    import qiime2.sdk
 
-    artifact = qiime.sdk.Artifact.import_data(type, input_path,
-                                              view_type=source_format)
+    artifact = qiime2.sdk.Artifact.import_data(type, input_path,
+                                               view_type=source_format)
     artifact.save(output_path)
 
 
-@tools.command(short_help='Take a peek at a QIIME Artifact or Visualization.',
-               help="Display basic information about a QIIME Artifact or "
+@tools.command(short_help='Take a peek at a QIIME 2 Artifact or '
+                          'Visualization.',
+               help="Display basic information about a QIIME 2 Artifact or "
                     "Visualization, including its UUID and type.")
 @click.argument('path', type=click.Path(exists=True, dir_okay=False))
 def peek(path):
-    import qiime.sdk
+    import qiime2.sdk
 
-    metadata = qiime.sdk.Result.peek(path)
+    metadata = qiime2.sdk.Result.peek(path)
 
     click.secho("UUID:        ", fg="green", nl=False)
     click.secho(metadata.uuid)
@@ -81,10 +82,10 @@ def peek(path):
         click.secho(metadata.format)
 
 
-@tools.command(short_help='View a QIIME Visualization.',
-               help="Displays a QIIME Visualization until the command exits. "
-                    "To open a QIIME Visualization so it can be used after "
-                    "the command exits, use 'qiime extract'.")
+@tools.command(short_help='View a QIIME 2 Visualization.',
+               help="Displays a QIIME 2 Visualization until the command "
+                    "exits. To open a QIIME 2 Visualization so it can be "
+                    "used after the command exits, use 'qiime extract'.")
 @click.argument('visualization-path',
                 type=click.Path(exists=True, dir_okay=False))
 @click.option('--index-extension', required=False, default='html',
@@ -100,18 +101,18 @@ def view(visualization_path, index_extension):
             'environment with a display and view it with `qiime tools view`.')
 
     import zipfile
-    import qiime.sdk
+    import qiime2.sdk
 
     if index_extension.startswith('.'):
         index_extension = index_extension[1:]
     try:
-        visualization = qiime.sdk.Visualization.load(visualization_path)
+        visualization = qiime2.sdk.Visualization.load(visualization_path)
     # TODO: currently a KeyError is raised if a zipped file that is not a
-    # QIIME result is passed. This should be handled better by the framework.
+    # QIIME 2 result is passed. This should be handled better by the framework.
     except (zipfile.BadZipFile, KeyError, TypeError):
         raise click.BadParameter(
-            '%s is not a QIIME Visualization. Only QIIME Visualizations can '
-            'be viewed.' % visualization_path)
+            '%s is not a QIIME 2 Visualization. Only QIIME 2 Visualizations '
+            'can be viewed.' % visualization_path)
 
     index_paths = visualization.get_index_paths(relative=False)
 
@@ -148,8 +149,9 @@ def view(visualization_path, index_extension):
                     break
 
 
-@tools.command(short_help="Extract a QIIME Artifact or Visualization archive.",
-               help="Extract all contents of a QIIME Artifact or "
+@tools.command(short_help="Extract a QIIME 2 Artifact or Visualization "
+                          "archive.",
+               help="Extract all contents of a QIIME 2 Artifact or "
                     "Visualization's archive, including provenance, metadata, "
                     "and actual data. Use 'qiime tools export' to export only "
                     "the data stored in an Artifact or Visualization, with "
@@ -162,13 +164,13 @@ def view(visualization_path, index_extension):
               default=os.getcwd())
 def extract(path, output_dir):
     import zipfile
-    import qiime.sdk
+    import qiime2.sdk
 
     try:
-        extracted_dir = qiime.sdk.Result.extract(path, output_dir)
+        extracted_dir = qiime2.sdk.Result.extract(path, output_dir)
     except (zipfile.BadZipFile, ValueError):
         raise click.BadParameter(
-            '%s is not a valid QIIME Result. Only QIIME Artifacts and '
+            '%s is not a valid QIIME 2 Result. Only QIIME 2 Artifacts and '
             'Visualizations can be extracted.' % path)
     else:
         click.echo('Extracted to %s' % extracted_dir)

--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
-# The full license is in the file COPYING.txt, distributed with this software.
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
 from setuptools import setup, find_packages
@@ -12,6 +12,7 @@ setup(
     name='q2cli',
     version='2017.2.0.dev0',
     license='BSD-3-Clause',
+    url='https://qiime2.org',
     packages=find_packages(),
     include_package_data=True,
     install_requires=['click', 'qiime2 == 2017.2.*', 'pip'],

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ from setuptools import setup, find_packages
 
 setup(
     name='q2cli',
-    version='0.0.7.dev0',
+    version='2017.2.0.dev0',
     license='BSD-3-Clause',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['click', 'qiime >= 2.0.6', 'pip'],
+    install_requires=['click', 'qiime2 == 2017.2.*', 'pip'],
     scripts=['bin/tab-qiime'],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
# ~~DO NOT MERGE~~

## ~~NOTE TO REVIEWER: please "rebase and merge," this PR contains standalone logical commits~~

`qiime` package is now `qiime2`.

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0,
  2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in
setup.py's `install_requires` to obtain patch releases for a given train
release.

The new versioning scheme is PEP 440 compliant.