### PR TITLE
ENH: remove `qiime dev plugin-init` in favor of direct Cookiecutter usage

### DIFF
--- a/q2cli/dev.py
+++ b/q2cli/dev.py
@@ -14,33 +14,6 @@ def dev():
     pass
 
 
-@dev.command(name='plugin-init',
-             short_help='Initialize plugin package from template.',
-             help="Initializes plugin package from template to specified"
-                  " output directory. Use this command if you are a"
-                  " plugin developer starting to develop a new plugin.")
-@click.pass_context
-@click.option('--output-dir', required=False,
-              type=click.Path(exists=False, file_okay=False, dir_okay=True,
-                              writable=True),
-              help='Directory in which to create plugin package.',
-              default='.')
-def plugin_init(ctx, output_dir):
-    import qiime2.plugin
-
-    try:
-        path = qiime2.plugin.plugin_init(output_dir=output_dir)
-    except FileExistsError as e:
-        click.secho("Plugin package directory name already exists under %s"
-                    % (output_dir if output_dir != '.' else
-                       'the current directory'),
-                    err=True, fg='red')
-        click.secho("Original error message:\n%s" % e, err=True, fg='red')
-        ctx.exit(1)
-    click.secho("Your plugin package has been created at %s" % path,
-                fg='green')
-
-
 @dev.command(name='refresh-cache',
              short_help='Refresh CLI cache.',
              help="Refresh the CLI cache. Use this command if you are "


### PR DESCRIPTION
The command was only a thin wrapper around Cookiecutter, which already has a Python API and CLI. It's easier to have plugin devs use Cookiecutter directly when templating a plugin, and lets us remove Cookiecutter as a framework dependency. There are instructions on the QIIME 2 docs site for using Cookiecutter.