### PR TITLE
`short_description` and `description` in output

### DIFF
--- a/q2cli/cache.py
+++ b/q2cli/cache.py
@@ -250,6 +250,8 @@ class DeploymentCache:
             'website': plugin.website,
             'citation_text': plugin.citation_text,
             'user_support_text': plugin.user_support_text,
+            'description': plugin.description,
+            'short_description': plugin.short_description,
             'actions': {}
         }
 

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -83,8 +83,8 @@ class RootCommand(click.MultiCommand):
         website = 'Plugin website: %s' % plugin['website']
         help_ = '\n\n'.join([website, support, citing])
 
-        return PluginCommand(plugin, name=name, 
-            short_help=plugin['description'], help=help_)
+        return PluginCommand(plugin, name=name,
+                             short_help=plugin['description'], help=help_)
 
 
 class PluginCommand(click.MultiCommand):

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -83,7 +83,8 @@ class RootCommand(click.MultiCommand):
         website = 'Plugin website: %s' % plugin['website']
         help_ = '\n\n'.join([website, support, citing])
 
-        return PluginCommand(plugin, name=name, short_help=plugin['description'], help=help_)
+        return PluginCommand(plugin, name=name, 
+            short_help=plugin['description'], help=help_)
 
 
 class PluginCommand(click.MultiCommand):

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -81,10 +81,11 @@ class RootCommand(click.MultiCommand):
         support = 'Getting user support: %s' % plugin['user_support_text']
         citing = 'Citing this plugin: %s' % plugin['citation_text']
         website = 'Plugin website: %s' % plugin['website']
-        help_ = '\n\n'.join([website, support, citing])
+        description = 'Description: %s' % plugin['description']
+        help_ = '\n\n'.join([description, website, support, citing])
 
         return PluginCommand(plugin, name=name,
-                             short_help=plugin['description'], help=help_)
+                             short_help=plugin['short_description'], help=help_)
 
 
 class PluginCommand(click.MultiCommand):

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -78,14 +78,12 @@ class RootCommand(click.MultiCommand):
         except KeyError:
             return None
 
-        # TODO: pass short_help=plugin.description, pending its
-        # existence: https://github.com/qiime2/qiime2/issues/81
         support = 'Getting user support: %s' % plugin['user_support_text']
         citing = 'Citing this plugin: %s' % plugin['citation_text']
         website = 'Plugin website: %s' % plugin['website']
         help_ = '\n\n'.join([website, support, citing])
 
-        return PluginCommand(plugin, name=name, short_help='', help=help_)
+        return PluginCommand(plugin, name=name, short_help=plugin['description'], help=help_)
 
 
 class PluginCommand(click.MultiCommand):

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -85,7 +85,7 @@ class RootCommand(click.MultiCommand):
         help_ = '\n\n'.join([description, website, support, citing])
 
         return PluginCommand(plugin, name=name,
-                             short_help=plugin['short_description'], 
+                             short_help=plugin['short_description'],
                              help=help_)
 
 

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -85,7 +85,8 @@ class RootCommand(click.MultiCommand):
         help_ = '\n\n'.join([description, website, support, citing])
 
         return PluginCommand(plugin, name=name,
-                             short_help=plugin['short_description'], help=help_)
+                             short_help=plugin['short_description'], 
+                             help=help_)
 
 
 class PluginCommand(click.MultiCommand):

--- a/q2cli/info.py
+++ b/q2cli/info.py
@@ -28,7 +28,7 @@ def _echo_plugins():
     if plugins:
         for name, plugin in sorted(plugins.items()):
             click.echo('%s %s\t\t%s' % (name,
-                       plugin['version'], plugin['short_description']))
+                       plugin['version']))
     else:
         click.secho('No plugins are currently installed.\nYou can browse '
                     'the official QIIME 2 plugins at https://qiime2.org')

--- a/q2cli/info.py
+++ b/q2cli/info.py
@@ -27,7 +27,7 @@ def _echo_plugins():
     plugins = q2cli.cache.CACHE.plugins
     if plugins:
         for name, plugin in sorted(plugins.items()):
-            click.echo('%s %s' % (name, plugin['version']))
+            click.echo('%s %s\t\t%s' % (name, plugin['version'], plugin['short_description']))
     else:
         click.secho('No plugins are currently installed.\nYou can browse '
                     'the official QIIME 2 plugins at https://qiime2.org')

--- a/q2cli/info.py
+++ b/q2cli/info.py
@@ -27,8 +27,7 @@ def _echo_plugins():
     plugins = q2cli.cache.CACHE.plugins
     if plugins:
         for name, plugin in sorted(plugins.items()):
-            click.echo('%s %s\t\t%s' % (name,
-                       plugin['version']))
+            click.echo('%s %s' % (name, plugin['version']))
     else:
         click.secho('No plugins are currently installed.\nYou can browse '
                     'the official QIIME 2 plugins at https://qiime2.org')

--- a/q2cli/info.py
+++ b/q2cli/info.py
@@ -27,8 +27,8 @@ def _echo_plugins():
     plugins = q2cli.cache.CACHE.plugins
     if plugins:
         for name, plugin in sorted(plugins.items()):
-            click.echo('%s %s\t\t%s' % (name, 
-                plugin['version'], plugin['short_description']))
+            click.echo('%s %s\t\t%s' % (name,
+                       plugin['version'], plugin['short_description']))
     else:
         click.secho('No plugins are currently installed.\nYou can browse '
                     'the official QIIME 2 plugins at https://qiime2.org')

--- a/q2cli/info.py
+++ b/q2cli/info.py
@@ -27,7 +27,8 @@ def _echo_plugins():
     plugins = q2cli.cache.CACHE.plugins
     if plugins:
         for name, plugin in sorted(plugins.items()):
-            click.echo('%s %s\t\t%s' % (name, plugin['version'], plugin['short_description']))
+            click.echo('%s %s\t\t%s' % (name, 
+                plugin['version'], plugin['short_description']))
     else:
         click.secho('No plugins are currently installed.\nYou can browse '
                     'the official QIIME 2 plugins at https://qiime2.org')


### PR DESCRIPTION
Added `short_description` of each installed plugin to print statement from `qiime info` output, and `description` from any given plugin to the output from running `qiime --help name-of-that-plugin`.

A simple test example can be seen in the output quoted [in my pull request to `q2-feature-table`](https://github.com/qiime2/q2-feature-table/pull/91).