### PR TITLE
attempt to add --show-importable-types option

### DIFF
--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -70,13 +70,12 @@ class CliTests(unittest.TestCase):
         result = self.runner.invoke(
             tools, ['import', '--show-importable-types'])
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue('IntSequence1' in result.output)
-        self.assertTrue('FourInts' in result.output)
-        self.assertTrue('IntSequence1' in result.output)
-        self.assertTrue('IntSequence2' in result.output)
-        self.assertTrue('Kennel[Cat]' in result.output)
-        self.assertTrue('Kennel[Dog]' in result.output)
-        self.assertTrue('Mapping' in result.output)
+
+        import qiime2.sdk
+        importable_types = sorted(qiime2.sdk.PluginManager().importable_types,
+                                key=repr)
+        for name in importable_types:
+            self.assertTrue(name in result.output)
 
     def test_extract(self):
         result = self.runner.invoke(

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -70,7 +70,6 @@ class CliTests(unittest.TestCase):
         result = self.runner.invoke(
             tools, ['import', '--show-importable-types'])
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue('IntSequence1' in result.output)
         self.assertTrue('FourInts' in result.output)
         self.assertTrue('IntSequence1' in result.output)
         self.assertTrue('IntSequence2' in result.output)

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -67,14 +67,16 @@ class CliTests(unittest.TestCase):
         self.assertFalse('mapping_viz' in commands)
 
     def test_show_importable_types(self):
-        import qiime2.sdk
         result = self.runner.invoke(
             tools, ['import', '--show-importable-types'])
         self.assertEqual(result.exit_code, 0)
-        importable_types = sorted(qiime2.sdk.PluginManager().importable_types,
-                                  key=repr)
-        for item in importable_types:
-            self.assertTrue(item.name in result.output)
+        self.assertTrue('IntSequence1' in result.output)
+        self.assertTrue('FourInts' in result.output)
+        self.assertTrue('IntSequence1' in result.output)
+        self.assertTrue('IntSequence2' in result.output)
+        self.assertTrue('Kennel[Cat]' in result.output)
+        self.assertTrue('Kennel[Dog]' in result.output)
+        self.assertTrue('Mapping' in result.output)
 
     def test_extract(self):
         result = self.runner.invoke(

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -70,6 +70,13 @@ class CliTests(unittest.TestCase):
         result = self.runner.invoke(
             tools, ['import', '--show-importable-types'])
         self.assertEqual(result.exit_code, 0)
+        self.assertTrue('IntSequence1' in result.output)
+        self.assertTrue('FourInts' in result.output)
+        self.assertTrue('IntSequence1' in result.output)
+        self.assertTrue('IntSequence2' in result.output)
+        self.assertTrue('Kennel[Cat]' in result.output)
+        self.assertTrue('Kennel[Dog]' in result.output)
+        self.assertTrue('Mapping' in result.output)
 
     def test_extract(self):
         result = self.runner.invoke(

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -67,15 +67,14 @@ class CliTests(unittest.TestCase):
         self.assertFalse('mapping_viz' in commands)
 
     def test_show_importable_types(self):
+        import qiime2.sdk
         result = self.runner.invoke(
             tools, ['import', '--show-importable-types'])
         self.assertEqual(result.exit_code, 0)
-
-        import qiime2.sdk
         importable_types = sorted(qiime2.sdk.PluginManager().importable_types,
-                                key=repr)
-        for name in importable_types:
-            self.assertTrue(name in result.output)
+                                  key=repr)
+        for item in importable_types:
+            self.assertTrue(item.name in result.output)
 
     def test_extract(self):
         result = self.runner.invoke(

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -66,6 +66,11 @@ class CliTests(unittest.TestCase):
         self.assertFalse('split_ints' in commands)
         self.assertFalse('mapping_viz' in commands)
 
+    def test_show_importable_types(self):
+        result = self.runner.invoke(
+            tools, ['import', '--show-importable-types'])
+        self.assertEqual(result.exit_code, 0)
+
     def test_extract(self):
         result = self.runner.invoke(
             tools, ['extract', self.artifact1_path, '--output-dir',

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -36,18 +36,21 @@ def export_data(path, output_dir):
     result = qiime2.sdk.Result.load(path)
     result.export_data(output_dir)
 
+
 def show_importable_types(ctx, param, value):
     import qiime2.sdk
 
     PluginManager = qiime2.sdk.PluginManager()
     set_of_importable_types = PluginManager.importable_types
-    set_of_importable_types = sorted([repr(t)for t in  set_of_importable_types])
+    set_of_importable_types = [repr(t) for t in set_of_importable_types]
+    set_of_importable_types = sorted(set_of_importable_types)
 
     if not value or ctx.resilient_parsing:
         return
     for name in set_of_importable_types:
         click.echo(name)
     ctx.exit()
+
 
 @tools.command(name='import',
                short_help='Import data into a new QIIME 2 Artifact.',
@@ -67,10 +70,9 @@ def show_importable_types(ctx, param, value):
               help='The format of the data to be imported. If not provided, '
                    'data must be in the format expected by the semantic type '
                    'provided via --type.')
-@click.option('--show-importable-types', is_flag=True, callback=show_importable_types,
-              expose_value=False, is_eager=True)
-
-
+@click.option('--show-importable-types', is_flag=True, is_eager=True,
+              callback=show_importable_types, expose_value=False,
+              help='Show the set of importable types.')
 def import_data(type, input_path, output_path, source_format=None):
     import qiime2.sdk
 

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -38,17 +38,20 @@ def export_data(path, output_dir):
 
 
 def show_importable_types(ctx, param, value):
-    import qiime2.sdk
-
-    PluginManager = qiime2.sdk.PluginManager()
-    set_of_importable_types = PluginManager.importable_types
-    set_of_importable_types = [repr(t) for t in set_of_importable_types]
-    set_of_importable_types = sorted(set_of_importable_types)
 
     if not value or ctx.resilient_parsing:
         return
-    for name in set_of_importable_types:
-        click.echo(name)
+
+    import qiime2.sdk
+
+    importable_types = sorted(qiime2.sdk.PluginManager().importable_types, key=repr)
+
+    if importable_types:
+        for name in importable_types:
+            click.echo(name)
+    else:
+        print('There are no importable types in the current deployment.')
+
     ctx.exit()
 
 

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -38,15 +38,10 @@ def export_data(path, output_dir):
 
 def show_importable_types(ctx, param, value):
     import qiime2.sdk
+
     PluginManager = qiime2.sdk.PluginManager()
     set_of_importable_types = PluginManager.importable_types
-    set_of_importable_types = sorted(set_of_importable_types)
-
-    # set_of_importable_types = list(set_of_importable_types)
-    # set_of_importable_types = sorted(set_of_importable_types)
-
-    # set_of_importable_types = list(set_of_importable_types)
-    # set_of_importable_types.sort()
+    set_of_importable_types = sorted([repr(t)for t in  set_of_importable_types])
 
     if not value or ctx.resilient_parsing:
         return

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -38,7 +38,8 @@ def export_data(path, output_dir):
 
 def show_importable_types(ctx, param, value):
     import qiime2.sdk
-    set_of_importable_types = qiime2.sdk.PluginManager.importable_types
+    PluginManager = qiime2.sdk.PluginManager()
+    set_of_importable_types = PluginManager.importable_types
 
     if not value or ctx.resilient_parsing:
         return

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -36,6 +36,14 @@ def export_data(path, output_dir):
     result = qiime2.sdk.Result.load(path)
     result.export_data(output_dir)
 
+def show_importable_types(ctx, param, value):
+    import qiime2.sdk
+    set_of_importable_types = qiime2.sdk.PluginManager.importable_types
+
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(set_of_importable_types)
+    ctx.exit()
 
 @tools.command(name='import',
                short_help='Import data into a new QIIME 2 Artifact.',
@@ -55,6 +63,10 @@ def export_data(path, output_dir):
               help='The format of the data to be imported. If not provided, '
                    'data must be in the format expected by the semantic type '
                    'provided via --type.')
+@click.option('--show-importable-types', is_flag=True, callback=show_importable_types,
+              expose_value=False, is_eager=True)
+
+
 def import_data(type, input_path, output_path, source_format=None):
     import qiime2.sdk
 

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -38,7 +38,6 @@ def export_data(path, output_dir):
 
 
 def show_importable_types(ctx, param, value):
-
     if not value or ctx.resilient_parsing:
         return
 

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -50,7 +50,7 @@ def show_importable_types(ctx, param, value):
         for name in importable_types:
             click.echo(name)
     else:
-        print('There are no importable types in the current deployment.')
+        click.echo('There are no importable types in the current deployment.')
 
     ctx.exit()
 

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -59,7 +59,9 @@ def show_importable_types(ctx, param, value):
                     "on the file types and associated semantic types that can "
                     "be imported.")
 @click.option('--type', required=True,
-              help='The semantic type of the new artifact.')
+              help='The semantic type of the artifact that will be created upon '
+                   'importing. Use --show-importable-types to see what importable semantic '
+                   'types are available in the current deployment.')
 @click.option('--input-path', required=True,
               type=click.Path(exists=True, dir_okay=True),
               help='Path to file or directory that should be imported.')
@@ -72,7 +74,8 @@ def show_importable_types(ctx, param, value):
                    'provided via --type.')
 @click.option('--show-importable-types', is_flag=True, is_eager=True,
               callback=show_importable_types, expose_value=False,
-              help='Show the set of importable types.')
+              help='Show the semantic types that can be supplied to --type '
+                   'to import data into an artifact.')
 def import_data(type, input_path, output_path, source_format=None):
     import qiime2.sdk
 

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -40,10 +40,18 @@ def show_importable_types(ctx, param, value):
     import qiime2.sdk
     PluginManager = qiime2.sdk.PluginManager()
     set_of_importable_types = PluginManager.importable_types
+    set_of_importable_types = sorted(set_of_importable_types)
+
+    # set_of_importable_types = list(set_of_importable_types)
+    # set_of_importable_types = sorted(set_of_importable_types)
+
+    # set_of_importable_types = list(set_of_importable_types)
+    # set_of_importable_types.sort()
 
     if not value or ctx.resilient_parsing:
         return
-    click.echo(set_of_importable_types)
+    for name in set_of_importable_types:
+        click.echo(name)
     ctx.exit()
 
 @tools.command(name='import',

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -44,7 +44,8 @@ def show_importable_types(ctx, param, value):
 
     import qiime2.sdk
 
-    importable_types = sorted(qiime2.sdk.PluginManager().importable_types, key=repr)
+    importable_types = sorted(qiime2.sdk.PluginManager().importable_types,
+                              key=repr)
 
     if importable_types:
         for name in importable_types:
@@ -62,9 +63,10 @@ def show_importable_types(ctx, param, value):
                     "on the file types and associated semantic types that can "
                     "be imported.")
 @click.option('--type', required=True,
-              help='The semantic type of the artifact that will be created upon '
-                   'importing. Use --show-importable-types to see what importable semantic '
-                   'types are available in the current deployment.')
+              help='The semantic type of the artifact that will be created '
+                   'upon importing. Use --show-importable-types to see what '
+                   'importable semantic types are available in the current '
+                   'deployment.')
 @click.option('--input-path', required=True,
               type=click.Path(exists=True, dir_okay=True),
               help='Path to file or directory that should be imported.')


### PR DESCRIPTION
I expected to get the set of importable types via `qiime2.sdk.PluginManager.importable_types`, but that just results in a property object.

```bash
(qiime2-dev) [aas229@wind ~/projects/qiime_dev/q2cli ]$ qiime tools import --show-importable-types
<property object at 0x7f1adf7b8318>
```

How can I actually access the set of importable types?