### PR TITLE
ENH: Add --quiet flag to method calls

### DIFF
--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -240,9 +240,9 @@ class ActionCommand(click.Command):
                 log.close()
                 os.remove(log.name)
 
-        if not quiet:
-            for result, output in zip(results, outputs):
-                path = result.save(output)
+        for result, output in zip(results, outputs):
+            path = result.save(output)
+            if not quiet:
                 click.secho('Saved %s to: %s' % (result.type, path),
                             fg='green')
 
@@ -266,6 +266,10 @@ class ActionCommand(click.Command):
 
         verbose = self.verbose_handler.get_value(kwargs, fallback=cmd_fallback)
         quiet = self.quiet_handler.get_value(kwargs, fallback=cmd_fallback)
+
+        if verbose and quiet:
+            raise ValueError('Unsure of how to be quiet and verbose at the '
+                             'same time.')
 
         for item in itertools.chain(self.action['signature']['inputs'],
                                     self.action['signature']['parameters']):

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -268,8 +268,9 @@ class ActionCommand(click.Command):
         quiet = self.quiet_handler.get_value(kwargs, fallback=cmd_fallback)
 
         if verbose and quiet:
-            raise ValueError('Unsure of how to be quiet and verbose at the '
-                             'same time.')
+            click.secho('Unsure of how to be quiet and verbose at the '
+                        'same time.', fg='red', bold=True, err=True)
+            click.get_current_context().exit(1)
 
         for item in itertools.chain(self.action['signature']['inputs'],
                                     self.action['signature']['parameters']):

--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -135,6 +135,33 @@ class VerboseHandler(Handler):
         return value
 
 
+class QuietHandler(Handler):
+    """Handler for quiet output (--quiet flag)."""
+
+    def __init__(self):
+        super().__init__('quiet', default=False)
+
+    def get_click_options(self):
+        import click
+
+        # `is_flag` will set the default to `False`, but `self._locate_value`
+        # needs to distinguish between the presence or absence of the flag
+        # provided by the user.
+        yield click.Option(
+            ['--' + self.cli_name], is_flag=True, default=None,
+            help='Silence output to stdout and/or stderr during '
+                 'execution of this action.  [default: %s]' % self.default)
+
+    def get_value(self, arguments, fallback=None):
+        value = self._locate_value(arguments, fallback)
+        # Value may have been specified in --cmd-config (or another source in
+        # the future). If we don't have a bool type yet, attempt to interpret a
+        # string representing a boolean.
+        if type(value) is not bool:
+            value = self._parse_boolean(value)
+        return value
+
+
 class OutputDirHandler(Handler):
     """Meta handler which returns a fallback function as its value."""
 

--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -149,8 +149,8 @@ class QuietHandler(Handler):
         # provided by the user.
         yield click.Option(
             ['--' + self.cli_name], is_flag=True, default=None,
-            help='Silence output to stdout and/or stderr during '
-                 'execution of this action.  [default: %s]' % self.default)
+            help='Silence output if execution is successful '
+                 '(silence is golden).  [default: %s]' % self.default)
 
     def get_value(self, arguments, fallback=None):
         value = self._locate_value(arguments, fallback)


### PR DESCRIPTION
Adds `--quiet` flag to `q2cli` that will suppress the success message once a method has been ran and the result objects saved.

Resolves #125 
