### PR TITLE
BUG: disallow repeated options

### DIFF
--- a/q2cli/__init__.py
+++ b/q2cli/__init__.py
@@ -6,7 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from .core import Option, option
 from ._version import get_versions
 
+__all__ = ['Option', 'option']
 __version__ = get_versions()['version']
 del get_versions

--- a/q2cli/core.py
+++ b/q2cli/core.py
@@ -1,0 +1,108 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import click
+
+import q2cli.util
+
+
+class Option(click.Option):
+    """``click.Option`` with customized behavior for q2cli.
+
+    Note to q2cli developers: you'll generally want to use this class and its
+    corresponding decorator (``@q2cli.option``) over ``click.Option`` and
+    ``@click.option`` to keep a consistent CLI behavior across commands. This
+    class and decorator are designed to be drop-in replacements for their Click
+    counterparts.
+
+    """
+    def __init__(self, param_decls=None, **attrs):
+        if 'multiple' not in attrs and 'count' not in attrs:
+            self._disallow_repeated_options(attrs)
+        super().__init__(param_decls=param_decls, **attrs)
+
+    def _disallow_repeated_options(self, attrs):
+        """Prevent option from being repeated on the command line.
+
+        Click allows options to be repeated on the command line and stores the
+        value of the last specified option (this is to support overriding
+        options set in shell aliases). While this is common behavior in CLI
+        tools, it is prevented in q2cli to avoid confusion with options that
+        are intended to be supplied multiple times (``multiple=True``; Click
+        calls these "multiple options"). QIIME 2 metadata is an example of a
+        "multiple option" in q2cli.
+
+        References
+        ----------
+        .. [1] http://click.pocoo.org/6/options/#multiple-options
+
+        """
+        # General strategy:
+        #
+        # Make this option a "multiple option" (``multiple=True``) and use a
+        # callback to unpack the stored values and assert that only a single
+        # value was supplied.
+
+        # Use the user-supplied callback or define a passthrough callback if
+        # one wasn't supplied.
+        if 'callback' in attrs:
+            callback = attrs['callback']
+        else:
+            def callback(ctx, param, value):
+                return value
+
+        # Wrap the callback to intercept stored values so that they can be
+        # unpacked and validated.
+        def callback_wrapper(ctx, param, value):
+            # When `multiple=True` Click will use an empty tuple to represent
+            # the absence of the option instead of `None`.
+            if value == ():
+                value = None
+            if not value or ctx.resilient_parsing:
+                return callback(ctx, param, value)
+
+            # Empty/null case is handled above, so attempt to unpack the value.
+            try:
+                value, = value
+            except ValueError:
+                click.echo(ctx.get_usage() + '\n', err=True)
+                click.secho(
+                    "Error: Option --%s was specified multiple times in the "
+                    "command." % q2cli.util.to_cli_name(param.name),
+                    err=True, fg='red', bold=True)
+                ctx.exit(1)
+
+            return callback(ctx, param, value)
+
+        # Promote this option to a "multiple option" and use the callback
+        # wrapper to make it behave like a regular "single" option.
+        attrs['callback'] = callback_wrapper
+        attrs['multiple'] = True
+
+        # If the user set a default, promote it to a "multiple option" default
+        # by putting it in a list. A default of `None` is a special case that
+        # can't be promoted.
+        if 'default' in attrs and attrs['default'] is not None:
+            attrs['default'] = [attrs['default']]
+
+
+# Modeled after `click.option` decorator.
+def option(*param_decls, **attrs):
+    """``@click.option`` decorator with customized behavior for q2cli.
+
+    See docstring on ``q2cli.Option`` (above) for details.
+
+    """
+    if 'cls' in attrs:
+        raise ValueError("Cannot override `cls=q2cli.Option` in `attrs`.")
+    attrs['cls'] = Option
+
+    def decorator(f):
+        return click.option(*param_decls, **attrs)(f)
+
+    return decorator

--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -115,12 +115,12 @@ class VerboseHandler(Handler):
         super().__init__('verbose', default=False)
 
     def get_click_options(self):
-        import click
+        import q2cli
 
         # `is_flag` will set the default to `False`, but `self._locate_value`
         # needs to distinguish between the presence or absence of the flag
         # provided by the user.
-        yield click.Option(
+        yield q2cli.Option(
             ['--' + self.cli_name], is_flag=True, default=None,
             help='Display verbose output to stdout and/or stderr during '
                  'execution of this action.  [default: %s]' % self.default)
@@ -142,12 +142,12 @@ class QuietHandler(Handler):
         super().__init__('quiet', default=False)
 
     def get_click_options(self):
-        import click
+        import q2cli
 
         # `is_flag` will set the default to `False`, but `self._locate_value`
         # needs to distinguish between the presence or absence of the flag
         # provided by the user.
-        yield click.Option(
+        yield q2cli.Option(
             ['--' + self.cli_name], is_flag=True, default=None,
             help='Silence output if execution is successful '
                  '(silence is golden).  [default: %s]' % self.default)
@@ -170,8 +170,9 @@ class OutputDirHandler(Handler):
 
     def get_click_options(self):
         import click
+        import q2cli
 
-        yield click.Option(
+        yield q2cli.Option(
             ['--' + self.cli_name],
             type=click.Path(exists=False, dir_okay=True, file_okay=False),
             help='Output unspecified results to a directory')
@@ -216,8 +217,9 @@ class CommandConfigHandler(Handler):
 
     def get_click_options(self):
         import click
+        import q2cli
 
-        yield click.Option(
+        yield q2cli.Option(
             ['--' + self.cli_name],
             type=click.Path(exists=True, dir_okay=False, file_okay=True,
                             readable=True),
@@ -269,8 +271,9 @@ class ArtifactHandler(GeneratedHandler):
 
     def get_click_options(self):
         import click
+        import q2cli
 
-        option = click.Option(['--' + self.cli_name],
+        option = q2cli.Option(['--' + self.cli_name],
                               type=click.Path(exists=False, dir_okay=False),
                               help="Artifact: %s  [required]" % self.repr)
         yield self._add_description(option)
@@ -287,8 +290,9 @@ class ResultHandler(GeneratedHandler):
 
     def get_click_options(self):
         import click
+        import q2cli
 
-        option = click.Option(['--' + self.cli_name],
+        option = q2cli.Option(['--' + self.cli_name],
                               type=click.Path(exists=False, dir_okay=False),
                               help="Artifact: %s  [required if not passing "
                               "--output-dir]" % self.repr)
@@ -318,6 +322,7 @@ class MetadataHandler(Handler):
 
     def get_click_options(self):
         import click
+        import q2cli
 
         name = '--' + self.cli_name
         type = click.Path(exists=True, dir_okay=False)
@@ -327,10 +332,10 @@ class MetadataHandler(Handler):
         # required.
         option = None
         if self.default is None:
-            option = click.Option([name], type=type,
+            option = q2cli.Option([name], type=type,
                                   help='%s  [optional]' % help)
         else:
-            option = click.Option([name], type=type,
+            option = q2cli.Option([name], type=type,
                                   help='%s  [required]' % help)
 
         yield self._add_description(option)
@@ -368,6 +373,7 @@ class MetadataCategoryHandler(Handler):
 
     def get_click_options(self):
         import click
+        import q2cli
 
         md_name = '--' + self.cli_names[0]
         md_help = 'Metadata mapping file'
@@ -390,8 +396,8 @@ class MetadataCategoryHandler(Handler):
             md_kwargs['help'] = '%s  [required]' % md_help
             mdc_kwargs['help'] = '%s  [required]' % mdc_help
 
-        yield click.Option([md_name], **md_kwargs)
-        yield click.Option([mdc_name], **mdc_kwargs)
+        yield q2cli.Option([md_name], **md_kwargs)
+        yield q2cli.Option([mdc_name], **mdc_kwargs)
 
     def get_value(self, arguments, fallback=None):
         import qiime2
@@ -472,7 +478,7 @@ class RegularParameterHandler(GeneratedHandler):
         return mapping[self.ast['name']]
 
     def get_click_options(self):
-        import click
+        import q2cli
         import q2cli.util
 
         type = self.get_type()  # Use the ugly lookup above
@@ -495,13 +501,13 @@ class RegularParameterHandler(GeneratedHandler):
         # value once the handlers are invoked.
         option = None
         if self.default is NoDefault:
-            option = click.Option([name], type=option_type, default=None,
+            option = q2cli.Option([name], type=option_type, default=None,
                                   show_default=False, help='[required]')
         elif self.default is None:
-            option = click.Option([name], type=option_type, default=None,
+            option = q2cli.Option([name], type=option_type, default=None,
                                   show_default=False, help='[optional]')
         else:
-            option = click.Option([name], type=option_type, default=None,
+            option = q2cli.Option([name], type=option_type, default=None,
                                   show_default=False,
                                   help='[default: %s]' % self.default)
 

--- a/q2cli/info.py
+++ b/q2cli/info.py
@@ -8,6 +8,8 @@
 
 import click
 
+import q2cli
+
 
 def _echo_version():
     import sys
@@ -65,9 +67,9 @@ def _echo_citations():
 
 
 @click.command(help='Display information about current deployment.')
-@click.option('--citations', is_flag=True,
+@q2cli.option('--citations', is_flag=True,
               help='Display citations for QIIME 2 and installed plugins.')
-@click.option('--py-packages', is_flag=True,
+@q2cli.option('--py-packages', is_flag=True,
               help='Display names and versions of all installed Python '
                    'packages.')
 def info(citations, py_packages):

--- a/q2cli/tests/test_core.py
+++ b/q2cli/tests/test_core.py
@@ -1,0 +1,93 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os.path
+import shutil
+import tempfile
+import unittest
+
+import click
+from click.testing import CliRunner
+from qiime2.core.testing.util import get_dummy_plugin
+
+import q2cli
+import q2cli.info
+import q2cli.tools
+from q2cli.commands import RootCommand
+
+
+class TestOption(unittest.TestCase):
+    def setUp(self):
+        get_dummy_plugin()
+        self.runner = CliRunner()
+        self.tempdir = tempfile.mkdtemp(prefix='qiime2-q2cli-test-temp-')
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def _assertRepeatedOptionError(self, result, option):
+        self.assertEqual(result.exit_code, 1)
+        self.assertTrue(result.output.startswith('Usage:'))
+        self.assertIn('%s was specified multiple times' % option,
+                      result.output)
+
+    def test_repeated_eager_option_with_callback(self):
+        result = self.runner.invoke(
+            q2cli.tools.tools,
+            ['import', '--show-importable-types', '--show-importable-types'])
+
+        self._assertRepeatedOptionError(result, '--show-importable-types')
+
+    def test_repeated_builtin_flag(self):
+        result = self.runner.invoke(
+            q2cli.info.info,
+            ['info', '--py-packages', '--py-packages'])
+
+        self._assertRepeatedOptionError(result, '--py-packages')
+
+    def test_repeated_action_flag(self):
+        qiime_cli = RootCommand()
+        command = qiime_cli.get_command(ctx=None, name='dummy-plugin')
+        out_path = os.path.join(self.tempdir, 'out.qza')
+
+        result = self.runner.invoke(
+            command, ['no-input-method', '--o-out', out_path,
+                      '--verbose', '--verbose'])
+
+        self._assertRepeatedOptionError(result, '--verbose')
+
+    def test_repeated_builtin_option(self):
+        input_path = os.path.join(self.tempdir, 'ints.txt')
+        with open(input_path, 'w') as f:
+            f.write('42\n43\n44\n')
+        output_path = os.path.join(self.tempdir, 'out.qza')
+
+        result = self.runner.invoke(
+            q2cli.tools.tools,
+            ['import', '--input-path', input_path,
+             '--output-path', output_path, '--type', 'IntSequence1',
+             '--type', 'IntSequence1'])
+
+        self._assertRepeatedOptionError(result, '--type')
+
+    def test_repeated_action_option(self):
+        qiime_cli = RootCommand()
+        command = qiime_cli.get_command(ctx=None, name='dummy-plugin')
+        out_path = os.path.join(self.tempdir, 'out.qza')
+
+        result = self.runner.invoke(
+            command, ['no-input-method', '--o-out', out_path,
+                      '--o-out', out_path])
+
+        self._assertRepeatedOptionError(result, '--o-out')
+
+
+class TestOptionDecorator(unittest.TestCase):
+    def test_cls_override(self):
+        with self.assertRaisesRegex(ValueError, 'override `cls=q2cli.Option`'):
+            q2cli.option('--bar', cls=click.Option)

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -10,6 +10,8 @@ import os
 
 import click
 
+import q2cli
+
 
 @click.group(help='Tools for working with QIIME 2 files.')
 def tools():
@@ -27,7 +29,7 @@ def tools():
                     "Visualization. Use 'qiime tools extract' to extract the "
                     "Artifact or Visualization's entire archive.")
 @click.argument('path', type=click.Path(exists=True, dir_okay=False))
-@click.option('--output-dir', required=True,
+@q2cli.option('--output-dir', required=True,
               type=click.Path(exists=False, dir_okay=True),
               help='Directory where data should be exported to')
 def export_data(path, output_dir):
@@ -79,30 +81,30 @@ def show_importable_formats(ctx, param, value):
                     "https://docs.qiime2.org/ for usage examples and details "
                     "on the file types and associated semantic types that can "
                     "be imported.")
-@click.option('--type', required=True,
+@q2cli.option('--type', required=True,
               help='The semantic type of the artifact that will be created '
                    'upon importing. Use --show-importable-types to see what '
                    'importable semantic types are available in the current '
                    'deployment.')
-@click.option('--input-path', required=True,
+@q2cli.option('--input-path', required=True,
               type=click.Path(exists=True, dir_okay=True),
               help='Path to file or directory that should be imported.')
-@click.option('--output-path', required=True,
+@q2cli.option('--output-path', required=True,
               type=click.Path(exists=False, dir_okay=False),
               help='Path where output artifact should be written.')
-@click.option('--source-format', required=False,
+@q2cli.option('--source-format', required=False,
               help='The format of the data to be imported. If not provided, '
                    'data must be in the format expected by the semantic type '
                    'provided via --type.')
-@click.option('--show-importable-types', is_flag=True, is_eager=True,
+@q2cli.option('--show-importable-types', is_flag=True, is_eager=True,
               callback=show_importable_types, expose_value=False,
               help='Show the semantic types that can be supplied to --type '
                    'to import data into an artifact.')
-@click.option('--show-importable-formats', is_flag=True, is_eager=True,
+@q2cli.option('--show-importable-formats', is_flag=True, is_eager=True,
               callback=show_importable_formats, expose_value=False,
               help='Show formats that can be supplied to --source-format to '
                    'import data into an artifact.')
-def import_data(type, input_path, output_path, source_format=None):
+def import_data(type, input_path, output_path, source_format):
     import qiime2.sdk
 
     artifact = qiime2.sdk.Artifact.import_data(type, input_path,
@@ -135,7 +137,7 @@ def peek(path):
                     "used after the command exits, use 'qiime extract'.")
 @click.argument('visualization-path',
                 type=click.Path(exists=True, dir_okay=False))
-@click.option('--index-extension', required=False, default='html',
+@q2cli.option('--index-extension', required=False, default='html',
               help='The extension of the index file that should be opened. '
                    '[default: html]')
 def view(visualization_path, index_extension):
@@ -205,7 +207,7 @@ def view(visualization_path, index_extension):
                     "the data stored in an Artifact or Visualization, with "
                     "the choice of exporting to different formats.")
 @click.argument('path', type=click.Path(exists=True, dir_okay=False))
-@click.option('--output-dir', required=False,
+@q2cli.option('--output-dir', required=False,
               type=click.Path(exists=True, dir_okay=True),
               help='Directory where archive should be extracted to '
                    '[default: current working directory]',


### PR DESCRIPTION
Click allows options to be repeated on the command line and stores the value of the last specified option (this is to support overriding options set in shell aliases). While this is common behavior in CLI tools, it is prevented in q2cli to avoid confusion with options that are intended to be supplied multiple times (``multiple=True``; Click calls these "multiple options"). QIIME 2 metadata is an example of a "multiple option" in q2cli.

To support this behavior, q2cli now has ``q2cli.Option`` and ``@q2cli.option``, which are intended to be drop-in replacements for their Click counterparts.

Fixes #143.