### PR TITLE
ENH: support multiple metadata options (metadata merging)

### DIFF
--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -14,8 +14,8 @@ import shutil
 from click.testing import CliRunner
 from qiime2 import Artifact, Visualization
 from qiime2.core.testing.type import IntSequence1
+from qiime2.core.testing.util import get_dummy_plugin
 from qiime2.core.archive import ImportProvenanceCapture
-
 
 from q2cli.info import info
 from q2cli.tools import tools
@@ -23,8 +23,8 @@ from q2cli.commands import RootCommand
 
 
 class CliTests(unittest.TestCase):
-
     def setUp(self):
+        get_dummy_plugin()
         self.runner = CliRunner()
         self.tempdir = tempfile.mkdtemp(prefix='qiime2-q2cli-test-temp-')
         self.artifact1_path = os.path.join(self.tempdir, 'a1.qza')
@@ -203,3 +203,124 @@ class CliTests(unittest.TestCase):
         viz = Visualization.load(expected_viz_path)
         self.assertEqual(viz.get_index_paths(), {'html': 'data/index.html',
                                                  'tsv': 'data/index.tsv'})
+
+
+class TestMetadataSupport(unittest.TestCase):
+    def setUp(self):
+        get_dummy_plugin()
+        self.runner = CliRunner()
+        self.plugin_command = RootCommand().get_command(
+            ctx=None, name='dummy-plugin')
+        self.tempdir = tempfile.mkdtemp(prefix='qiime2-q2cli-test-temp-')
+
+        self.input_artifact = os.path.join(self.tempdir, 'in.qza')
+        Artifact.import_data(
+            IntSequence1, [0, 42, 43], list).save(self.input_artifact)
+        self.output_artifact = os.path.join(self.tempdir, 'out.qza')
+
+        self.metadata_file1 = os.path.join(self.tempdir, 'metadata1.tsv')
+        with open(self.metadata_file1, 'w') as f:
+            f.write('id\tcol1\n0\tfoo\nid1\tbar\n')
+
+        self.metadata_file2 = os.path.join(self.tempdir, 'metadata2.tsv')
+        with open(self.metadata_file2, 'w') as f:
+            f.write('id\tcol2\n0\tbaz\nid1\tbaa\n')
+
+        self.metadata_artifact = os.path.join(self.tempdir, 'metadata.qza')
+        Artifact.import_data(
+            'Mapping', {'a': 'dog', 'b': 'cat'}).save(self.metadata_artifact)
+
+        self.cmd_config = os.path.join(self.tempdir, 'conf.ini')
+        with open(self.cmd_config, 'w') as f:
+            f.write('[dummy-plugin.identity-with-metadata]\n'
+                    'm-metadata-file=%s\n' % self.metadata_file1)
+            f.write('[dummy-plugin.identity-with-optional-metadata]\n'
+                    'm-metadata-file=%s\n' % self.metadata_file1)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def _run_command(self, *args):
+        return self.runner.invoke(self.plugin_command, args)
+
+    def _assertMetadataOutput(self, result, *, exp_tsv, exp_yaml):
+        self.assertEqual(result.exit_code, 0)
+
+        artifact = Artifact.load(self.output_artifact)
+        action_dir = artifact._archiver.provenance_dir / 'action'
+
+        if exp_tsv is None:
+            self.assertFalse((action_dir / 'metadata.tsv').exists())
+        else:
+            with (action_dir / 'metadata.tsv').open() as fh:
+                self.assertEqual(fh.read(), exp_tsv)
+
+        with (action_dir / 'action.yaml').open() as fh:
+            self.assertIn(exp_yaml, fh.read())
+
+    def test_required_metadata_missing(self):
+        result = self._run_command(
+            'identity-with-metadata', '--i-ints', self.input_artifact,
+            '--o-out', self.output_artifact)
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertTrue(result.output.startswith('Usage:'))
+        self.assertIn("Missing option: --m-metadata-file", result.output)
+
+    def test_optional_metadata_missing(self):
+        result = self._run_command(
+            'identity-with-optional-metadata', '--i-ints', self.input_artifact,
+            '--o-out', self.output_artifact, '--verbose')
+
+        self._assertMetadataOutput(result, exp_tsv=None,
+                                   exp_yaml='metadata: null')
+
+    def test_single_metadata(self):
+        for command in ('identity-with-metadata',
+                        'identity-with-optional-metadata'):
+            result = self._run_command(
+                command, '--i-ints', self.input_artifact, '--o-out',
+                self.output_artifact, '--m-metadata-file', self.metadata_file1,
+                '--verbose')
+
+            self._assertMetadataOutput(
+                result, exp_tsv='id\tcol1\n0\tfoo\nid1\tbar\n',
+                exp_yaml="metadata: !metadata 'metadata.tsv'")
+
+    def test_multiple_metadata(self):
+        for command in ('identity-with-metadata',
+                        'identity-with-optional-metadata'):
+            result = self._run_command(
+                command, '--i-ints', self.input_artifact, '--o-out',
+                self.output_artifact, '--m-metadata-file', self.metadata_file1,
+                '--m-metadata-file', self.metadata_file2, '--m-metadata-file',
+                self.metadata_artifact, '--verbose')
+
+            exp_yaml = "metadata: !metadata '%s:metadata.tsv'" % (
+                Artifact.load(self.metadata_artifact).uuid)
+            self._assertMetadataOutput(
+                result, exp_tsv='\tcol1\tcol2\ta\tb\n0\tfoo\tbaz\tdog\tcat\n',
+                exp_yaml=exp_yaml)
+
+    def test_invalid_metadata_merge(self):
+        for command in ('identity-with-metadata',
+                        'identity-with-optional-metadata'):
+            result = self._run_command(
+                command, '--i-ints', self.input_artifact, '--o-out',
+                self.output_artifact, '--m-metadata-file', self.metadata_file1,
+                '--m-metadata-file', self.metadata_file1)
+
+            self.assertEqual(result.exit_code, -1)
+            self.assertIn('overlapping categories', str(result.exception))
+
+    def test_cmd_config_metadata(self):
+        for command in ('identity-with-metadata',
+                        'identity-with-optional-metadata'):
+            result = self._run_command(
+                command, '--i-ints', self.input_artifact, '--o-out',
+                self.output_artifact, '--cmd-config', self.cmd_config,
+                '--verbose')
+
+            self._assertMetadataOutput(
+                result, exp_tsv='id\tcol1\n0\tfoo\nid1\tbar\n',
+                exp_yaml="metadata: !metadata 'metadata.tsv'")

--- a/q2cli/tests/test_core.py
+++ b/q2cli/tests/test_core.py
@@ -17,7 +17,6 @@ from qiime2 import Artifact
 from qiime2.core.testing.type import IntSequence1
 from qiime2.core.testing.util import get_dummy_plugin
 
-
 import q2cli
 import q2cli.info
 import q2cli.tools

--- a/q2cli/tests/test_core.py
+++ b/q2cli/tests/test_core.py
@@ -13,7 +13,10 @@ import unittest
 
 import click
 from click.testing import CliRunner
+from qiime2 import Artifact
+from qiime2.core.testing.type import IntSequence1
 from qiime2.core.testing.util import get_dummy_plugin
+
 
 import q2cli
 import q2cli.info
@@ -85,6 +88,33 @@ class TestOption(unittest.TestCase):
                       '--o-out', out_path])
 
         self._assertRepeatedOptionError(result, '--o-out')
+
+    def test_repeated_multiple_option(self):
+        input_path = os.path.join(self.tempdir, 'ints.qza')
+        artifact = Artifact.import_data(IntSequence1, [0, 42, 43], list)
+        artifact.save(input_path)
+
+        metadata_path1 = os.path.join(self.tempdir, 'metadata1.tsv')
+        with open(metadata_path1, 'w') as f:
+            f.write('id\tcol1\nid1\tfoo\nid2\tbar\n')
+        metadata_path2 = os.path.join(self.tempdir, 'metadata2.tsv')
+        with open(metadata_path2, 'w') as f:
+            f.write('id\tcol2\nid1\tbaz\nid2\tbaa\n')
+
+        output_path = os.path.join(self.tempdir, 'out.qza')
+
+        qiime_cli = RootCommand()
+        command = qiime_cli.get_command(ctx=None, name='dummy-plugin')
+
+        result = self.runner.invoke(
+            command, ['identity-with-metadata', '--i-ints', input_path,
+                      '--o-out', output_path, '--m-metadata-file',
+                      metadata_path1, '--m-metadata-file', metadata_path2,
+                      '--verbose'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(os.path.exists(output_path))
+        self.assertEqual(Artifact.load(output_path).view(list), [0, 42, 43])
 
 
 class TestOptionDecorator(unittest.TestCase):


### PR DESCRIPTION
## Note to merger

Please "Squash and Merge" with the following content as the commit message (the PR title is fine to use as the commit message title):

Adds support for supplying multiple `--m-metadata-file` options, including usage with a metadata category. If multiple metadata files are provided they are merged.

Refactored (mostly rewrote) `MetadataHandler` and `MetadataCategoryHandler` to reduce code duplication. `MetadataCategoryHandler` now composes with `MetadataHandler`.

Added fairly comprehensive unit tests for metadata support in q2cli (there weren't really existing tests for metadata).

Fixed a bug where a metadata category's `description` wasn't displayed in help text.

Fixes #140.