### PR TITLE
ENH: debug log path is easier to select

### DIFF
--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -230,7 +230,7 @@ class ActionCommand(click.Command):
             else:
                 traceback.print_exc(file=log)
                 click.echo(err=True)
-                self._echo_plugin_error(e, 'Debug info has been saved to %s.'
+                self._echo_plugin_error(e, 'Debug info has been saved to %s'
                                         % log.name)
             click.get_current_context().exit(1)
         else:


### PR DESCRIPTION
Removed trailing period from the debug log message, making it possible to double-click on the path name (e.g. to copy and paste) in terminal emulators. Previously, double-clicking on the log path would include the trailing period, which is usually not what you want.