### PR TITLE
ENH: let `make test` handle QIIMETEST env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ install:
   - make install
 script:
   - make lint
-  - QIIMETEST= make test-cov
+  - make test
   - QIIMETEST= source tab-qiime
-  - QIIMETEST= qiime
+  - QIIMETEST= qiime info

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint test test-cov install dev clean distclean
+.PHONY: all lint test install dev clean distclean
 
 all: ;
 
@@ -7,10 +7,7 @@ lint:
 	flake8
 
 test: all
-	nosetests
-
-test-cov: all
-	nosetests
+	QIIMETEST= nosetests
 
 install: all
 	python setup.py install


### PR DESCRIPTION
Previously:

```
QIIMETEST= make test
```

Now:

```
make test
```

:tada:

Also removed the `test-cov` target because coverage isn't set up for this package (yet).