### PR TITLE
BUG: remove text wrapping from error handling util

### DIFF
--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -44,8 +44,7 @@ def exit_with_error(e, header='An error has been encountered:', file=None,
     else:
         footer = 'Debug info has been saved to %s' % file.name
 
-    error = textwrap.indent(
-        '\n'.join(textwrap.wrap(str(e))), '  ')
+    error = textwrap.indent(str(e), '  ')
 
     segments = [header, error]
     if not suppress_footer:


### PR DESCRIPTION
Using `textwrap.wrap` in `q2cli.util.exit_with_error` was swallowing newlines in the error messages it displays, and sometimes these newlines are important to separate sections of content within the error message (e.g. `validate` errors from the framework). By avoiding text wrapping, the original formatting of the error message is preserved.

This change is in line with the goals of #146 by avoiding explicit text wrapping within q2cli.