### PR TITLE
MAINT: new Metadata updates

### DIFF
--- a/q2cli/tests/test_core.py
+++ b/q2cli/tests/test_core.py
@@ -120,3 +120,7 @@ class TestOptionDecorator(unittest.TestCase):
     def test_cls_override(self):
         with self.assertRaisesRegex(ValueError, 'override `cls=q2cli.Option`'):
             q2cli.option('--bar', cls=click.Option)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Detects old-style metadata category option names and suggests new names.

Describes expected metadata column type(s) in help text (metavar).

Raises informative and well-formatted error messages if a column can't be found or the column is an incorrect type.

See qiime2/qiime2#359 for details.