### PR TITLE
BUG: preserve Metadata ID header when not merging Metadata

### DIFF
--- a/q2cli/handlers.py
+++ b/q2cli/handlers.py
@@ -479,7 +479,10 @@ class MetadataHandler(Handler):
                         q2cli.util.exit_with_error(
                             e, header=header, file=dev_null,
                             suppress_footer=True)
-        return metadata[0].merge(*metadata[1:])
+        if len(metadata) == 1:
+            return metadata[0]
+        else:
+            return metadata[0].merge(*metadata[1:])
 
 
 class MetadataColumnHandler(Handler):


### PR DESCRIPTION
Previously, when a single Metadata was provided as input, the ID header was
normalized to 'id' instead of keeping the original value (e.g. '#SampleID').

New behavior is to retain original ID header when not merging, and normalize
the ID header to 'id' when a merge happens.

Depends on https://github.com/qiime2/qiime2/pull/367