### PR TITLE
BUG: fixes export for EXDEV situations

### DIFF
--- a/q2cli/tests/test_tools.py
+++ b/q2cli/tests/test_tools.py
@@ -7,10 +7,8 @@
 # ----------------------------------------------------------------------------
 
 import os
-import errno
 import shutil
 import unittest
-import unittest.mock as mock
 import tempfile
 
 from click.testing import CliRunner
@@ -19,8 +17,6 @@ from qiime2.core.testing.util import get_dummy_plugin
 
 from q2cli.tools import tools
 from q2cli.commands import RootCommand
-
-EXDEV = OSError(errno.EXDEV, "Invalid cross-device link")
 
 
 class TestInspectMetadata(unittest.TestCase):
@@ -189,7 +185,6 @@ class TestInspectMetadata(unittest.TestCase):
         self.assertIn('0', file)
         self.assertIn('42', file)
         self.assertIn('43', file)
-
 
     def test_export_visualization_to_dir(self):
         output_path = os.path.join(self.tempdir, 'output')

--- a/q2cli/tests/test_tools.py
+++ b/q2cli/tests/test_tools.py
@@ -7,8 +7,10 @@
 # ----------------------------------------------------------------------------
 
 import os
+import errno
 import shutil
 import unittest
+import unittest.mock as mock
 import tempfile
 
 from click.testing import CliRunner
@@ -17,6 +19,8 @@ from qiime2.core.testing.util import get_dummy_plugin
 
 from q2cli.tools import tools
 from q2cli.commands import RootCommand
+
+EXDEV = OSError(errno.EXDEV, "Invalid cross-device link")
 
 
 class TestInspectMetadata(unittest.TestCase):
@@ -171,6 +175,21 @@ class TestInspectMetadata(unittest.TestCase):
         self.assertIn('0', file)
         self.assertIn('42', file)
         self.assertIn('43', file)
+
+    def test_export_to_file_creates_directories(self):
+        output_path = os.path.join(self.tempdir, 'somewhere', 'output')
+        result = self.runner.invoke(tools, [
+            'export', '--input-path', self.ints1, '--output-path', output_path,
+            '--output-format', 'IntSequenceFormatV2'
+            ])
+
+        with open(output_path, 'r') as f:
+            file = f.read()
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('0', file)
+        self.assertIn('42', file)
+        self.assertIn('43', file)
+
 
     def test_export_visualization_to_dir(self):
         output_path = os.path.join(self.tempdir, 'output')

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -38,6 +38,7 @@ def tools():
               help='Format which the data should be exported as. '
               'This option cannot be used with Visualizations')
 def export_data(input_path, output_path, output_format):
+    import qiime2.util
     import qiime2.sdk
     import distutils
     result = qiime2.sdk.Result.load(input_path)
@@ -55,7 +56,7 @@ def export_data(input_path, output_path, output_format):
         else:
             source = result.view(qiime2.sdk.parse_format(output_format))
             if os.path.isfile(str(source)):
-                os.renames(str(source), output_path)
+                qiime2.util.duplicate(str(source), output_path)
             else:
                 distutils.dir_util.copy_tree(str(source), output_path)
 

--- a/q2cli/tools.py
+++ b/q2cli/tools.py
@@ -56,6 +56,11 @@ def export_data(input_path, output_path, output_format):
         else:
             source = result.view(qiime2.sdk.parse_format(output_format))
             if os.path.isfile(str(source)):
+                if os.path.isfile(output_path):
+                    os.remove(output_path)
+                else:
+                    # create directory (recursively) if it doesn't exist yet
+                    os.makedirs(os.path.dirname(output_path), exist_ok=True)
                 qiime2.util.duplicate(str(source), output_path)
             else:
                 distutils.dir_util.copy_tree(str(source), output_path)


### PR DESCRIPTION
This should correct issues with cross-device links (e.g. os.rename).

I don't have an obvious way to test this, but I could try something with mocks maybe.
TODO:
 - [x] Write a test or two