### PR TITLE
BUG: ignore unset var in conditional activation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ install: all
 	cp hooks/50_activate_q2cli_tab_completion.sh $(PREFIX)/etc/conda/activate.d/
 
 dev: all
-	pip install -e .
+	pip install -e . && \
+	mkdir -p $(PREFIX)/etc/conda/activate.d && \
+	cp hooks/50_activate_q2cli_tab_completion.sh $(PREFIX)/etc/conda/activate.d/
 
 clean: distclean
 

--- a/hooks/50_activate_q2cli_tab_completion.sh
+++ b/hooks/50_activate_q2cli_tab_completion.sh
@@ -1,5 +1,5 @@
-if [ -n "$ZSH_VERSION" ]; then
+if [ -n "${ZSH_VERSION-}" ]; then
   autoload bashcompinit && bashcompinit && source tab-qiime
-elif [ -n "$BASH_VERSION" ]; then
+elif [ -n "${BASH_VERSION-}" ]; then
   source tab-qiime
 fi


### PR DESCRIPTION
fixes #200 

See: https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion

Unfortunately, it looks like there are some other scripts with this problem, namely:
https://github.com/bioconda/bioconda-recipes/blob/c2e55df081bd1e8449bc64949d2d3f6d1a080f63/recipes/arb-bio/activate.sh