### PR TITLE
BUG: fix completion permissions for root installed env

### DIFF
--- a/q2cli/core/completion.py
+++ b/q2cli/core/completion.py
@@ -51,7 +51,8 @@ def write_bash_completion_script(plugins, path):
     # Make bash completion script executable:
     #   http://stackoverflow.com/a/12792002/3776794
     st = os.stat(path)
-    os.chmod(path, st.st_mode | stat.S_IEXEC)
+    # Set executable bit for user,group,other for root/sudo installs
+    os.chmod(path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def _generate_command_reply(cmd):


### PR DESCRIPTION
Ran into this at STAMPS. A root conda environment (like `/opt/`) will not allow users to tab-complete as they do not have the executable bit set.

Tested manually by inspection of the flags.

cc @AstrobioMike