### PR TITLE
MAINT: Replace some remaining sechos with CONFIG.cfg_style

### DIFF
--- a/q2cli/click/command.py
+++ b/q2cli/click/command.py
@@ -80,7 +80,7 @@ class BaseCommandMixin:
                     initial_indent=' (%d/%d%s) ' % (idx, len(errors),
                                                     '?' if skip_rest else ''),
                     subsequent_indent='  ')
-                click.secho(CONFIG.cfg_style('error', msg), err=True)
+                click.echo(CONFIG.cfg_style('error', msg), err=True)
             ctx.exit(1)
 
         ctx.args = args

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -13,6 +13,7 @@ import q2cli.builtin.info
 import q2cli.builtin.tools
 
 from q2cli.click.command import BaseCommandMixin
+from q2cli.core.config import CONFIG
 
 
 class RootCommand(BaseCommandMixin, click.MultiCommand):
@@ -44,10 +45,10 @@ class RootCommand(BaseCommandMixin, click.MultiCommand):
 
         if invalid_chars or categories:
             if invalid_chars:
-                click.secho("Error: Detected invalid character in: %s\n"
-                            "Verify the correct quotes or dashes (ASCII) are "
-                            "being used." % ', '.join(invalid_chars),
-                            err=True, fg='red', bold=True)
+                msg = ("Error: Detected invalid character in: %s\nVerify the "
+                       "correct quotes or dashes (ASCII) are being used."
+                       % ', '.join(invalid_chars))
+                click.echo(CONFIG.cfg_style('error', msg), err=True)
             if categories:
                 old_to_new_names = '\n'.join(
                     'Instead of %s, trying using %s' % (old, new)
@@ -55,7 +56,7 @@ class RootCommand(BaseCommandMixin, click.MultiCommand):
                 msg = ("Error: The following options no longer exist because "
                        "metadata *categories* are now called metadata "
                        "*columns* in QIIME 2.\n\n%s" % old_to_new_names)
-                click.secho(msg, err=True, fg='red', bold=True)
+                click.echo(CONFIG.cfg_style('error', msg), err=True)
             sys.exit(-1)
 
         super().__init__(*args, **kwargs)
@@ -108,9 +109,10 @@ class RootCommand(BaseCommandMixin, click.MultiCommand):
             else:
                 hint = ''
 
-            click.secho("Error: QIIME 2 has no plugin/command named %r."
-                        % name + hint,
-                        err=True, fg='red')
+            click.echo(
+                CONFIG.cfg_style('error', "Error: QIIME 2 has no "
+                                 "plugin/command named %r." % name + hint,
+                                 err=True))
             ctx.exit(2)  # Match exit code of `return None`
 
         return PluginCommand(plugin, name)
@@ -185,9 +187,10 @@ class PluginCommand(BaseCommandMixin, click.MultiCommand):
             else:
                 hint = ''
 
-            click.secho("Error: QIIME 2 plugin %r has no action %r."
-                        % (self._plugin['name'], name) + hint,
-                        err=True, fg='red')
+            click.echo(
+                CONFIG.cfg_style('error', "Error: QIIME 2 plugin %r has no "
+                                 "action %r." % (self._plugin['name'], name) +
+                                 hint), err=True)
             ctx.exit(2)  # Match exit code of `return None`
 
         return ActionCommand(name, self._plugin, action)
@@ -333,8 +336,9 @@ class ActionCommand(BaseCommandMixin, click.Command):
         for result, output in zip(results, outputs):
             path = result.save(output)
             if not quiet:
-                click.secho('Saved %s to: %s' % (result.type, path),
-                            fg='green')
+                click.echo(
+                    CONFIG.cfg_style('success', 'Saved %s to: %s' %
+                                     (result.type, path)))
 
     def _order_outputs(self, outputs):
         ordered = []

--- a/q2cli/core/config.py
+++ b/q2cli/core/config.py
@@ -36,6 +36,8 @@ class CLIConfig():
             try:
                 self.parse_file(self.path)
             except Exception as e:
+                # Let's just be safe and make no attempt to use CONFIG to
+                # format this text if the CONFIG is broken
                 click.secho(
                     "We encountered the following error when parsing your "
                     f"theme:\n\n{str(e)}\n\nIf you want to use a custom "
@@ -43,7 +45,7 @@ class CLIConfig():
                     "current theme. If you encountered this message while "
                     "importing a new theme or resetting your current theme, "
                     "ignore it.",
-                    fg='yellow')
+                    fg='red')
                 self.styles = self.get_default_styles()
         else:
             self.styles = self.get_default_styles()

--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -171,7 +171,7 @@ def citations_option(get_citation_records):
                 click.echo(fh.getvalue(), nl=False)
             ctx.exit()
         else:
-            click.secho(
+            click.echo(
                 CONFIG.cfg_style('problem', 'No citations found.'), err=True)
             ctx.exit(1)
 


### PR DESCRIPTION
Some text was still using `click.secho` not `CONFIG.cfg_style`. I think I replaced all relevant instances of this.
