### PR TITLE
MAINT: Reduce time to generate action help text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 
 # vi
 .*.swp
+
+# Ignore .DS_Store files for Mac users
+.DS_Store

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -14,7 +14,6 @@ import q2cli.builtin.tools
 
 from q2cli.click.command import BaseCommandMixin
 from q2cli.core.config import CONFIG
-from q2cli.core.cache import DeploymentCache
 
 
 class RootCommand(BaseCommandMixin, click.MultiCommand):

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -12,10 +12,9 @@ import q2cli.builtin.dev
 import q2cli.builtin.info
 import q2cli.builtin.tools
 
-from q2cli.core.config import CONFIG
-
 from q2cli.click.command import BaseCommandMixin
 from q2cli.core.config import CONFIG
+from q2cli.core.cache import DeploymentCache
 
 
 class RootCommand(BaseCommandMixin, click.MultiCommand):
@@ -226,7 +225,7 @@ class ActionCommand(BaseCommandMixin, click.Command):
 
         options = [*self._inputs, *self._params, *self._outputs, *self._misc]
         help_ = [action['description']]
-        if self._get_action().deprecated:
+        if self.action['deprecated']:
             help_.append(CONFIG.cfg_style(
                 'warning', 'WARNING:\n\nThis command is deprecated and will '
                            'be removed in a future version of this plugin.'))

--- a/q2cli/core/cache.py
+++ b/q2cli/core/cache.py
@@ -270,7 +270,8 @@ class DeploymentCache:
             'id': action.id,
             'name': action.name,
             'description': action.description,
-            'signature': []
+            'signature': [],
+            'deprecated': action.deprecated
         }
 
         sig = action.signature

--- a/q2cli/core/cache.py
+++ b/q2cli/core/cache.py
@@ -271,7 +271,7 @@ class DeploymentCache:
             'name': action.name,
             'description': action.description,
             'signature': [],
-            'deprecated': action.deprecated
+            'deprecated': action.deprecated,
         }
 
         sig = action.signature


### PR DESCRIPTION
This PR is meant to reduce time needed to generate action help text (Issue https://github.com/qiime2/docs/issues/429). The Deprecated API was previously using the Plugin Manager to check for a `deprecated` field in each plugin action. Use of the Plugin Manager to access the state of a plugin action makes action help text generation slow.

The state for plugins and plugin actions are initialized whenever a new conda environment is created, or when the cache is refreshed using the command `qiime dev refresh-cache`. This PR adds a deprecated field while checking the state of each plugin action. The `state.json` file is then "written to" with the updated state fields (including the deprecated field), and is used to provide quick access to plugin action state information. 

See timed results for the following command below: `time qiime gneiss ols-regression --help`
The "real" time is used to evaluate the performance of the command. See issue for previous benchmark.

----

![image](https://user-images.githubusercontent.com/30784905/63876710-eebbf800-c97a-11e9-960d-e3918a6a2b36.png)
