### PR TITLE
IMP: Improved error message when inappropriate primitive passed

### DIFF
--- a/q2cli/click/option.py
+++ b/q2cli/click/option.py
@@ -169,7 +169,7 @@ class GeneratedOption(click.Option):
                 args = ', '.join(map(repr, (x.type for x in value)))
                 if value not in type_expr:
                     raise click.BadParameter(
-                        'recieved <%s> as an argument, which is incompatible'
+                        'received <%s> as an argument, which is incompatible'
                         ' with parameter type: %r' % (args, type_expr),
                         ctx=ctx, param=self)
                 return value
@@ -195,7 +195,7 @@ class GeneratedOption(click.Option):
                     args = ', '.join(map(repr, value))
                     expr = qiime2.sdk.util.type_from_ast(self.q2_ast)
                     raise click.BadParameter(
-                        'recieved <%s> as an argument, which is incompatible'
+                        'received <%s> as an argument, which is incompatible'
                         ' with parameter type: %r' % (args, expr),
                         ctx=ctx, param=self)
                 return value
@@ -210,5 +210,5 @@ class GeneratedOption(click.Option):
         args = ', '.join(map(repr, value))
         if dups:
             raise click.BadParameter(
-                'recieved <%s> as an argument, which contains duplicates'
+                'received <%s> as an argument, which contains duplicates'
                 ' of the following: <%s>' % (args, dups), ctx=ctx, param=self)

--- a/q2cli/click/type.py
+++ b/q2cli/click/type.py
@@ -195,11 +195,10 @@ class QIIME2Type(click.ParamType):
         try:
             return qiime2.sdk.util.parse_primitive(self.type_expr, value)
         except ValueError:
-            args = ', '.join(map(repr, value))
             expr = qiime2.sdk.util.type_from_ast(self.type_ast)
             raise click.BadParameter(
                 'received <%s> as an argument, which is incompatible'
-                ' with parameter type: %r' % (args, expr),
+                ' with parameter type: %r' % (value, expr),
                 ctx=ctx)
 
     @property

--- a/q2cli/click/type.py
+++ b/q2cli/click/type.py
@@ -198,7 +198,7 @@ class QIIME2Type(click.ParamType):
             args = ', '.join(map(repr, value))
             expr = qiime2.sdk.util.type_from_ast(self.type_ast)
             raise click.BadParameter(
-                'recieved <%s> as an argument, which is incompatible'
+                'received <%s> as an argument, which is incompatible'
                 ' with parameter type: %r' % (args, expr),
                 ctx=ctx)
 

--- a/q2cli/click/type.py
+++ b/q2cli/click/type.py
@@ -192,7 +192,15 @@ class QIIME2Type(click.ParamType):
     def _convert_primitive(self, value, param, ctx):
         import qiime2.sdk.util
 
-        return qiime2.sdk.util.parse_primitive(self.type_expr, value)
+        try:
+            return qiime2.sdk.util.parse_primitive(self.type_expr, value)
+        except ValueError:
+            args = ', '.join(map(repr, value))
+            expr = qiime2.sdk.util.type_from_ast(self.type_ast)
+            raise click.BadParameter(
+                'recieved <%s> as an argument, which is incompatible'
+                ' with parameter type: %r' % (args, expr),
+                ctx=ctx)
 
     @property
     def name(self):


### PR DESCRIPTION
Closes #222 by making the error message look more in line with the current error that can be thrown by `type_cast_value`. This is the error message:

![Selection_095](https://user-images.githubusercontent.com/10642616/64050798-f079ed00-cb2d-11e9-988c-73a011b5ab8f.png)
