### PR TITLE
BUG: keyword error from misplaced paren

### DIFF
--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -111,8 +111,8 @@ class RootCommand(BaseCommandMixin, click.MultiCommand):
 
             click.echo(
                 CONFIG.cfg_style('error', "Error: QIIME 2 has no "
-                                 "plugin/command named %r." % name + hint,
-                                 err=True))
+                                 "plugin/command named %r." % name + hint),
+                                 err=True)
             ctx.exit(2)  # Match exit code of `return None`
 
         return PluginCommand(plugin, name)


### PR DESCRIPTION
Paren was in the wrong place causing a TypeError and traceback.