### PR TITLE
BUG: q2cli usage handing bad typestrings to framework for TypeMaps

### DIFF
--- a/q2cli/core/usage.py
+++ b/q2cli/core/usage.py
@@ -202,6 +202,9 @@ class CLIRenderer:
     def _template_outputs(self, output_opts):
         for opt_name, (ref, qiime_type) in output_opts.items():
             opt_name = to_cli_name(opt_name)
+            # Remove the superscript characters introduced for TypeMap
+            qiime_type = qiime_type.translate(
+                str.maketrans('', '', '⁰¹²³⁴⁵⁶⁷⁸⁹'))
             qiime_type = util.parse_type(qiime_type)
             ext = 'qzv' if util.is_visualization_type(qiime_type) else 'qza'
             yield f'--o-{opt_name} {ref}.{ext}'


### PR DESCRIPTION
closes #264

This works under limited manual testing, but has no unit tests yet. 

Existing [q2cli tests](https://github.com/qiime2/qiime2/blob/master/qiime2/core/testing/plugin.py) are using the dummy plugin. The dummy plugin [doesn't have any TypeMapped Actions](https://github.com/qiime2/qiime2/blob/master/qiime2/core/testing/plugin.py) we can use.

**Questions**
1. Should I write a TypeMapped action for the dummy plugin, and then use that in testing here, or is there a reason TypeMap isn't represented there yet?
2. `_template_metadata` also hands type expressions to util.parse_type(). Are Metadata/MetadataCategory type expressions also annotated with superscript numerals?