### PR TITLE
BUG: fix namespace collision when names differ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ lint:
 test: all
 	QIIMETEST= pytest
 
+# install pytest-xdist plugin for the `-n auto` argument.
 mystery-stew: all
 	MYSTERY_STEW= pytest -k mystery_stew -n auto
 

--- a/q2cli/core/usage.py
+++ b/q2cli/core/usage.py
@@ -201,7 +201,9 @@ class CLIUsage(usage.Usage):
         return var
 
     def view_as_metadata(self, name, variable):
-        var = super().view_as_metadata(variable.name, variable)
+        # use the given name so that namespace behaves as expected,
+        # then overwrite it because viewing is a no-op in q2cli
+        var = super().view_as_metadata(name, variable)
         # preserve the original interface name of the QZA as this will be
         # implicitly converted to metadata when executed.
         var._q2cli_ref = variable.to_interface_name()


### PR DESCRIPTION
When mutliple `use.view_as_metadata()` where used on the same original variable (with different names provided), a namespace collision occurs. This happened because the variable returned by super() was actually named after the metadata variable, rather than the user supplied variable.

Behavior is still the same as the interface_name is still immediately overwritten.