### PR TITLE
Cache cli output dir

### DIFF
--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -290,6 +290,17 @@ class ActionCommand(BaseCommandMixin, click.Command):
         from qiime2.core.cache import Cache
 
         output_dir = kwargs.pop('output_dir')
+        # If they gave us a cache and key combo as an output dir, we want to
+        # error out, so we check if their output dir contains a : and the part
+        # before it is a cache
+        if output_dir:
+            potential_cache = output_dir.rsplit(':', 1)[0]
+            if potential_cache and os.path.exists(potential_cache) and \
+                    Cache.is_cache(potential_cache):
+                raise ValueError(f"The given output dir '{output_dir}' "
+                                 "appears to be a cache:key combo. Cache keys "
+                                 "cannot be used as output dirs.")
+
         verbose = kwargs.pop('verbose')
         if verbose is None:
             verbose = False

--- a/q2cli/tests/test_cache_cli.py
+++ b/q2cli/tests/test_cache_cli.py
@@ -286,6 +286,27 @@ class TestCacheCli(unittest.TestCase):
         self.assertEqual(result.exit_code, 1)
         self.assertIn('is not a valid cache', result.output)
 
+    def test_output_dir_as_cache(self):
+        self.cache.save(self.art1, 'art1')
+        self.cache.save(self.art2, 'art2')
+        self.cache.save(self.art3, 'art3')
+
+        art1_path = str(self.cache.path) + ':art1'
+        art2_path = str(self.cache.path) + ':art2'
+        art3_path = str(self.cache.path) + ':art3'
+
+        out_path = str(self.cache.path) + ':out'
+
+        result = self._run_command(
+            'concatenate-ints', '--i-ints1', art1_path, '--i-ints2', art2_path,
+            '--i-ints3', art3_path, '--p-int1', '9', '--p-int2', '10',
+            '--output-dir', out_path, '--verbose'
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn(
+            'Cache keys cannot be used as output dirs.', str(result.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2cli/tests/test_cache_cli.py
+++ b/q2cli/tests/test_cache_cli.py
@@ -254,7 +254,7 @@ class TestCacheCli(unittest.TestCase):
         )
 
         self.assertEqual(result.exit_code, 1)
-        self.assertIn('Key must be a valid Python identifier',
+        self.assertIn('Keys must be valid Python identifiers',
                       str(result.exception))
 
     def test_artifact_as_metadata_cache(self):

--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -96,9 +96,10 @@ def output_in_cache(fp):
         if Cache.is_cache(cache_path):
             if not key.isidentifier():
                 raise ValueError(
-                    'Key must be a valid Python identifier. Python identifier '
-                    'rules may be found here https://www.askpython.com/python/'
-                    'python-identifiers-rules-best-practices')
+                    f"Key '{key}' is not a valid Python identifier. Keys must "
+                    "be valid Python identifiers. Python identifier rules may "
+                    "be found here https://www.askpython.com/python/"
+                    "python-identifiers-rules-best-practices")
             else:
                 return True
     except FileNotFoundError as e:


### PR DESCRIPTION
Raises a better error when trying to use a cache:key as an output dir
