### PR TITLE
bug: adds user permissions in cache testing for osx

### DIFF
--- a/q2cli/tests/test_tools.py
+++ b/q2cli/tests/test_tools.py
@@ -649,6 +649,7 @@ class TestCacheTools(unittest.TestCase):
 
     def test_cache_validate_bad(self):
         self.cache.save(self.art1, 'key')
+        set_permissions(self.cache.path, ALL_PERMISSIONS, ALL_PERMISSIONS)
         os.rename(self.cache.data / str(self.art1.uuid),
                   self.cache.data / 'not_uuid')
 


### PR DESCRIPTION
this PR fixes a bug in the unit tests for cache that required user permissions to be manually set for osx