### PR TITLE
View in cache

### DIFF
--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -696,12 +696,18 @@ def cache_garbage_collection(path):
               help='The key to save the artifact under (must be a valid '
                    'Python identifier).')
 def cache_save(cache_path, artifact_path, key):
-    from qiime2 import Artifact
+    from qiime2 import Artifact, Visualization
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
-        artifact = Artifact.load(artifact_path)
+        try:
+            artifact = Artifact.load(artifact_path)
+        except TypeError as e:
+            if 'Attempting to load Visualization' in str(e):
+                artifact = Visualization.load(artifact_path)
+            else:
+                raise e
         cache = Cache(cache_path)
         cache.save(artifact, key)
     except Exception as e:

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -441,6 +441,7 @@ def _merge_metadata(paths):
 def view(visualization_path, index_extension):
     # Guard headless envs from having to import anything large
     import sys
+    from qiime2 import Visualization
     from q2cli.util import _load_input
     from q2cli.core.config import CONFIG
     if not os.getenv("DISPLAY") and sys.platform != "darwin":
@@ -454,6 +455,12 @@ def view(visualization_path, index_extension):
         index_extension = index_extension[1:]
 
     visualization = _load_input(visualization_path, view=True)[0]
+    if not isinstance(visualization, Visualization):
+        raise click.BadParameter(
+            '%s is not a QIIME 2 Visualization. Only QIIME 2 Visualizations '
+            'can be viewed.' % visualization_path)
+
+
     index_paths = visualization.get_index_paths(relative=False)
 
     if index_extension not in index_paths:

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -686,18 +686,12 @@ def cache_garbage_collection(path):
               help='The key to save the artifact under (must be a valid '
                    'Python identifier).')
 def cache_save(cache_path, artifact_path, key):
-    from qiime2 import Artifact, Visualization
+    from qiime2.sdk.result import Result
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
-        try:
-            artifact = Artifact.load(artifact_path)
-        except TypeError as e:
-            if 'Attempting to load Visualization' in str(e):
-                artifact = Visualization.load(artifact_path)
-            else:
-                raise e
+        artifact = Result.load(artifact_path)
         cache = Cache(cache_path)
         cache.save(artifact, key)
     except Exception as e:

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -434,14 +434,14 @@ def _merge_metadata(paths):
                     "used after the command exits, use 'qiime tools extract'.",
                cls=ToolCommand)
 @click.argument('visualization-path', metavar='VISUALIZATION',
-                type=click.Path(exists=True, file_okay=True, dir_okay=False,
-                                readable=True))
+                type=click.Path(file_okay=True, dir_okay=False, readable=True))
 @click.option('--index-extension', required=False, default='html',
               help='The extension of the index file that should be opened. '
                    '[default: html]')
 def view(visualization_path, index_extension):
     # Guard headless envs from having to import anything large
     import sys
+    from q2cli.util import _load_input
     from q2cli.core.config import CONFIG
     if not os.getenv("DISPLAY") and sys.platform != "darwin":
         raise click.UsageError(
@@ -450,20 +450,10 @@ def view(visualization_path, index_extension):
             'https://view.qiime2.org, or move the Visualization to an '
             'environment with a display and view it with `qiime tools view`.')
 
-    import zipfile
-    import qiime2.sdk
-
     if index_extension.startswith('.'):
         index_extension = index_extension[1:]
-    try:
-        visualization = qiime2.sdk.Visualization.load(visualization_path)
-    # TODO: currently a KeyError is raised if a zipped file that is not a
-    # QIIME 2 result is passed. This should be handled better by the framework.
-    except (zipfile.BadZipFile, KeyError, TypeError):
-        raise click.BadParameter(
-            '%s is not a QIIME 2 Visualization. Only QIIME 2 Visualizations '
-            'can be viewed.' % visualization_path)
 
+    visualization = _load_input(visualization_path, view=True)[0]
     index_paths = visualization.get_index_paths(relative=False)
 
     if index_extension not in index_paths:

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -460,7 +460,6 @@ def view(visualization_path, index_extension):
             '%s is not a QIIME 2 Visualization. Only QIIME 2 Visualizations '
             'can be viewed.' % visualization_path)
 
-
     index_paths = visualization.get_index_paths(relative=False)
 
     if index_extension not in index_paths:

--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -333,9 +333,11 @@ def _load_metadata_artifact(fp):
         return None, error
 
 
-def _load_input(fp):
-    # just initialize the plugin manager
-    _ = get_plugin_manager()
+def _load_input(fp, view=False):
+    # Just initialize the plugin manager. This is slow and not necessary if we
+    # called this from qiime tools view.
+    if not view:
+        _ = get_plugin_manager()
 
     if ':' in fp:
         artifact, error = _load_input_cache(fp)


### PR DESCRIPTION
Allows for a cache:key to be handed to `qiime tools view`. Also allows visualizations to be saved to cache using `qiime tools cache-save`
