### PR TITLE
SQUASH: Rename tools and args

### DIFF
--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -606,20 +606,20 @@ def citations(path):
                short_help='Create an empty cache at the given location.',
                help='Create an empty cache at the given location.',
                cls=ToolCommand)
-@click.option('--path', required=True,
+@click.option('--cache-path', required=True,
               type=click.Path(exists=False, readable=True),
               help='Path to a nonexistent directory to be created as a cache.')
-def cache_create(path):
+def cache_create(cache_path):
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
-        Cache(path)
+        Cache(cache_path)
     except Exception as e:
-        header = "There was a problem creating a cache at '%s':" % path
+        header = "There was a problem creating a cache at '%s':" % cache_path
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
-    success = "Created cache at '%s'" % path
+    success = "Created cache at '%s'" % cache_path
     click.echo(CONFIG.cfg_style('success', success))
 
 
@@ -628,25 +628,25 @@ def cache_create(path):
                help='Removes a given key from a cache then runs garbage '
                     'collection on the cache.',
                cls=ToolCommand)
-@click.option('--path', required=True,
+@click.option('--cache-path', required=True,
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
                               readable=True),
               help='Path to an existing cache to remove the key from.')
 @click.option('--key', required=True,
               help='The key to remove from the cache.')
-def cache_remove(path, key):
+def cache_remove(cache_path, key):
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
-        cache = Cache(path)
+        cache = Cache(cache_path)
         cache.remove(key)
     except Exception as e:
         header = "There was a problem removing the key '%s' from the " \
-                 "cache '%s':" % (key, path)
+                 "cache '%s':" % (key, cache_path)
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
-    success = "Removed key '%s' from cache '%s'" % (key, path)
+    success = "Removed key '%s' from cache '%s'" % (key, cache_path)
     click.echo(CONFIG.cfg_style('success', success))
 
 
@@ -656,29 +656,29 @@ def cache_remove(path, key):
                help='Runs garbage collection on the cache at the specified '
                     'location if the specified location is a cache.',
                cls=ToolCommand)
-@click.option('--path', required=True,
+@click.option('--cache-path', required=True,
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
                               readable=True),
               help='Path to an existing cache to run garbage collection on.')
-def cache_garbage_collection(path):
+def cache_garbage_collection(cache_path):
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
-        cache = Cache(path)
+        cache = Cache(cache_path)
         cache.garbage_collection()
     except Exception as e:
         header = "There was a problem running garbage collection on the " \
-            "cache at '%s':" % path
+            "cache at '%s':" % cache_path
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
-    success = "Ran garbage collection on cache at '%s'" % path
+    success = "Ran garbage collection on cache at '%s'" % cache_path
     click.echo(CONFIG.cfg_style('success', success))
 
 
-@tools.command(name='cache-save',
-               short_help='Saves a .qza into the cache under a key.',
-               help='Saves a .qza into the cache under a key.',
+@tools.command(name='cache-store',
+               short_help='Stores a .qza in the cache under a key.',
+               help='Stores a .qza in the cache under a key.',
                cls=ToolCommand)
 @click.option('--cache-path', required=True,
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
@@ -691,7 +691,7 @@ def cache_garbage_collection(path):
 @click.option('--key', required=True,
               help='The key to save the artifact under (must be a valid '
                    'Python identifier).')
-def cache_save(cache_path, artifact_path, key):
+def cache_store(cache_path, artifact_path, key):
     from qiime2.sdk.result import Result
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
@@ -710,9 +710,9 @@ def cache_save(cache_path, artifact_path, key):
     click.echo(CONFIG.cfg_style('success', success))
 
 
-@tools.command(name='cache-load',
-               short_help='Loads an artifact out of a cache into a .qza.',
-               help='Loads the artifact saved to the specified cache under '
+@tools.command(name='cache-fetch',
+               short_help='Fetches an artifact out of a cache into a .qza.',
+               help='Fetches the artifact saved to the specified cache under '
                     'the specified key into a .qza at the specified location.',
                cls=ToolCommand)
 @click.option('--cache-path', required=True,
@@ -724,7 +724,7 @@ def cache_save(cache_path, artifact_path, key):
 @click.option('--output-path', required=True,
               type=click.Path(exists=False, readable=True),
               help='Path to put the .qza we are loading the artifact into.')
-def cache_load(cache_path, key, output_path):
+def cache_fetch(cache_path, key, output_path):
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
@@ -749,11 +749,11 @@ def cache_load(cache_path, key, output_path):
                     'pointed to by keys to data and lists the number of '
                     'artifacts in the pool for keys to pools.',
                cls=ToolCommand)
-@click.option('--path', required=True,
+@click.option('--cache-path', required=True,
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
                               readable=True),
               help='Path to an existing cache to check the status of.')
-def cache_status(path):
+def cache_status(cache_path):
     from qiime2.core.cache import Cache
     from qiime2.sdk.result import Result
 
@@ -762,7 +762,7 @@ def cache_status(path):
     data_output = []
     pool_output = []
     try:
-        cache = Cache(path)
+        cache = Cache(cache_path)
         with cache.lock:
             for key in cache.get_keys():
                 key_values = cache.read_key(key)
@@ -777,7 +777,7 @@ def cache_status(path):
                         (key, str(len(os.listdir(cache.pools / pool)))))
     except Exception as e:
         header = "There was a problem getting the status of the cache at " \
-                 "path '%s':" % path
+                 "path '%s':" % cache_path
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
     if not data_output:
@@ -793,5 +793,6 @@ def cache_status(path):
         pool_output = 'Pool keys in cache:\n' + pool_output
 
     output = data_output + '\n\n' + pool_output
-    success = "Status of the cache at the path '%s':\n\n%s" % (path, output)
+    success = "Status of the cache at the path '%s':\n\n%s" % \
+        (cache_path, output)
     click.echo(CONFIG.cfg_style('success', success))

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -606,20 +606,20 @@ def citations(path):
                short_help='Create an empty cache at the given location.',
                help='Create an empty cache at the given location.',
                cls=ToolCommand)
-@click.option('--cache-path', required=True,
+@click.option('--cache', required=True,
               type=click.Path(exists=False, readable=True),
               help='Path to a nonexistent directory to be created as a cache.')
-def cache_create(cache_path):
+def cache_create(cache):
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
-        Cache(cache_path)
+        Cache(cache)
     except Exception as e:
-        header = "There was a problem creating a cache at '%s':" % cache_path
+        header = "There was a problem creating a cache at '%s':" % cache
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
-    success = "Created cache at '%s'" % cache_path
+    success = "Created cache at '%s'" % cache
     click.echo(CONFIG.cfg_style('success', success))
 
 
@@ -628,25 +628,25 @@ def cache_create(cache_path):
                help='Removes a given key from a cache then runs garbage '
                     'collection on the cache.',
                cls=ToolCommand)
-@click.option('--cache-path', required=True,
+@click.option('--cache', required=True,
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
                               readable=True),
               help='Path to an existing cache to remove the key from.')
 @click.option('--key', required=True,
               help='The key to remove from the cache.')
-def cache_remove(cache_path, key):
+def cache_remove(cache, key):
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
-        cache = Cache(cache_path)
-        cache.remove(key)
+        _cache = Cache(cache)
+        _cache.remove(key)
     except Exception as e:
         header = "There was a problem removing the key '%s' from the " \
-                 "cache '%s':" % (key, cache_path)
+                 "cache '%s':" % (key, cache)
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
-    success = "Removed key '%s' from cache '%s'" % (key, cache_path)
+    success = "Removed key '%s' from cache '%s'" % (key, cache)
     click.echo(CONFIG.cfg_style('success', success))
 
 
@@ -656,23 +656,23 @@ def cache_remove(cache_path, key):
                help='Runs garbage collection on the cache at the specified '
                     'location if the specified location is a cache.',
                cls=ToolCommand)
-@click.option('--cache-path', required=True,
+@click.option('--cache', required=True,
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
                               readable=True),
               help='Path to an existing cache to run garbage collection on.')
-def cache_garbage_collection(cache_path):
+def cache_garbage_collection(cache):
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
-        cache = Cache(cache_path)
-        cache.garbage_collection()
+        _cache = Cache(cache)
+        _cache.garbage_collection()
     except Exception as e:
         header = "There was a problem running garbage collection on the " \
-            "cache at '%s':" % cache_path
+            "cache at '%s':" % cache
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
-    success = "Ran garbage collection on cache at '%s'" % cache_path
+    success = "Ran garbage collection on cache at '%s'" % cache
     click.echo(CONFIG.cfg_style('success', success))
 
 
@@ -680,7 +680,7 @@ def cache_garbage_collection(cache_path):
                short_help='Stores a .qza in the cache under a key.',
                help='Stores a .qza in the cache under a key.',
                cls=ToolCommand)
-@click.option('--cache-path', required=True,
+@click.option('--cache', required=True,
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
                               readable=True),
               help='Path to an existing cache to save into.')
@@ -691,22 +691,22 @@ def cache_garbage_collection(cache_path):
 @click.option('--key', required=True,
               help='The key to save the artifact under (must be a valid '
                    'Python identifier).')
-def cache_store(cache_path, artifact_path, key):
+def cache_store(cache, artifact_path, key):
     from qiime2.sdk.result import Result
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
         artifact = Result.load(artifact_path)
-        cache = Cache(cache_path)
-        cache.save(artifact, key)
+        _cache = Cache(cache)
+        _cache.save(artifact, key)
     except Exception as e:
         header = "There was a problem saving the artifact '%s' to the cache " \
-                 "'%s' under the key '%s':" % (artifact_path, cache_path, key)
+                 "'%s' under the key '%s':" % (artifact_path, cache, key)
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
     success = "Saved the artifact '%s' to the cache '%s' under the key " \
-        "'%s'" % (artifact_path, cache_path, key)
+        "'%s'" % (artifact_path, cache, key)
     click.echo(CONFIG.cfg_style('success', success))
 
 
@@ -715,7 +715,7 @@ def cache_store(cache_path, artifact_path, key):
                help='Fetches the artifact saved to the specified cache under '
                     'the specified key into a .qza at the specified location.',
                cls=ToolCommand)
-@click.option('--cache-path', required=True,
+@click.option('--cache', required=True,
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
                               readable=True),
               help='Path to an existing cache to load from.')
@@ -724,22 +724,22 @@ def cache_store(cache_path, artifact_path, key):
 @click.option('--output-path', required=True,
               type=click.Path(exists=False, readable=True),
               help='Path to put the .qza we are loading the artifact into.')
-def cache_fetch(cache_path, key, output_path):
+def cache_fetch(cache, key, output_path):
     from qiime2.core.cache import Cache
     from q2cli.core.config import CONFIG
 
     try:
-        cache = Cache(cache_path)
-        artifact = cache.load(key)
+        _cache = Cache(cache)
+        artifact = _cache.load(key)
         artifact.save(output_path)
     except Exception as e:
         header = "There was a problem loading the artifact with the key " \
                  "'%s' from the cache '%s' and saving it to the file '%s':" % \
-                 key, cache_path, output_path
+                 key, cache, output_path
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
     success = "Loaded artifact with the key '%s' from the cache '%s' and " \
-        "saved it to the file '%s'" % (key, cache_path, output_path)
+        "saved it to the file '%s'" % (key, cache, output_path)
     click.echo(CONFIG.cfg_style('success', success))
 
 
@@ -749,11 +749,11 @@ def cache_fetch(cache_path, key, output_path):
                     'pointed to by keys to data and lists the number of '
                     'artifacts in the pool for keys to pools.',
                cls=ToolCommand)
-@click.option('--cache-path', required=True,
+@click.option('--cache', required=True,
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
                               readable=True),
               help='Path to an existing cache to check the status of.')
-def cache_status(cache_path):
+def cache_status(cache):
     from qiime2.core.cache import Cache
     from qiime2.sdk.result import Result
 
@@ -762,22 +762,22 @@ def cache_status(cache_path):
     data_output = []
     pool_output = []
     try:
-        cache = Cache(cache_path)
-        with cache.lock:
-            for key in cache.get_keys():
-                key_values = cache.read_key(key)
+        _cache = Cache(cache)
+        with _cache.lock:
+            for key in _cache.get_keys():
+                key_values = _cache.read_key(key)
 
                 if (data := key_values['data']) is not None:
                     data_output.append(
                         'data: %s -> %s' %
-                        (key, str(Result.peek(cache.data / data))))
+                        (key, str(Result.peek(_cache.data / data))))
                 elif (pool := key_values['pool']) is not None:
                     pool_output.append(
                         'pool: %s -> size = %s' %
-                        (key, str(len(os.listdir(cache.pools / pool)))))
+                        (key, str(len(os.listdir(_cache.pools / pool)))))
     except Exception as e:
         header = "There was a problem getting the status of the cache at " \
-                 "path '%s':" % cache_path
+                 "path '%s':" % cache
         q2cli.util.exit_with_error(e, header=header, traceback=None)
 
     if not data_output:
@@ -794,5 +794,5 @@ def cache_status(cache_path):
 
     output = data_output + '\n\n' + pool_output
     success = "Status of the cache at the path '%s':\n\n%s" % \
-        (cache_path, output)
+        (cache, output)
     click.echo(CONFIG.cfg_style('success', success))

--- a/q2cli/tests/test_tools.py
+++ b/q2cli/tests/test_tools.py
@@ -472,7 +472,7 @@ class TestCacheTools(unittest.TestCase):
         cache_path = os.path.join(self.tempdir.name, 'created_cache')
 
         result = self.runner.invoke(
-            tools, ['cache-create', '--cache-path', cache_path])
+            tools, ['cache-create', '--cache', cache_path])
 
         success = "Created cache at '%s'\n" % cache_path
         self.assertEqual(success, result.output)
@@ -484,8 +484,7 @@ class TestCacheTools(unittest.TestCase):
 
         result = self.runner.invoke(
             tools,
-            ['cache-remove', '--cache-path', str(self.cache.path), '--key',
-             'key'])
+            ['cache-remove', '--cache', str(self.cache.path), '--key', 'key'])
 
         success = "Removed key 'key' from cache '%s'\n" % self.cache.path
         self.assertEqual(success, result.output)
@@ -529,7 +528,7 @@ class TestCacheTools(unittest.TestCase):
         gc.collect()
         result = self.runner.invoke(
             tools,
-            ['cache-garbage-collection', '--cache-path', str(self.cache.path)])
+            ['cache-garbage-collection', '--cache', str(self.cache.path)])
 
         success = "Ran garbage collection on cache at '%s'\n" % self.cache.path
         self.assertEqual(success, result.output)
@@ -543,7 +542,7 @@ class TestCacheTools(unittest.TestCase):
         self.art1.save(artifact)
 
         result = self.runner.invoke(
-            tools, ['cache-store', '--cache-path', str(self.cache.path),
+            tools, ['cache-store', '--cache', str(self.cache.path),
                     '--artifact-path', artifact, '--key', 'key'])
 
         success = "Saved the artifact '%s' to the cache '%s' under the key " \
@@ -555,7 +554,7 @@ class TestCacheTools(unittest.TestCase):
         self.cache.save(self.art1, 'key')
 
         result = self.runner.invoke(
-            tools, ['cache-fetch', '--cache-path', str(self.cache.path),
+            tools, ['cache-fetch', '--cache', str(self.cache.path),
                     '--key', 'key', '--output-path', artifact])
 
         success = "Loaded artifact with the key 'key' from the cache '%s' " \
@@ -569,7 +568,7 @@ class TestCacheTools(unittest.TestCase):
         self.art1.save(in_artifact)
 
         result = self.runner.invoke(
-            tools, ['cache-store', '--cache-path', str(self.cache.path),
+            tools, ['cache-store', '--cache', str(self.cache.path),
                     '--artifact-path', in_artifact, '--key', 'key'])
 
         success = "Saved the artifact '%s' to the cache '%s' under the key " \
@@ -577,7 +576,7 @@ class TestCacheTools(unittest.TestCase):
         self.assertEqual(success, result.output)
 
         result = self.runner.invoke(
-            tools, ['cache-fetch', '--cache-path', str(self.cache.path),
+            tools, ['cache-fetch', '--cache', str(self.cache.path),
                     '--key', 'key', '--output-path', out_artifact])
 
         success = "Loaded artifact with the key 'key' from the cache '%s' " \
@@ -593,7 +592,7 @@ class TestCacheTools(unittest.TestCase):
 
         # Empty cache
         result = self.runner.invoke(
-            tools, ['cache-status', '--cache-path', str(self.cache.path)])
+            tools, ['cache-status', '--cache', str(self.cache.path)])
         success = \
             success_template % (str(self.cache.path), 'No data keys in cache',
                                 'No pool keys in cache')
@@ -603,11 +602,11 @@ class TestCacheTools(unittest.TestCase):
         in_artifact = os.path.join(self.tempdir.name, 'in_artifact.qza')
         self.art1.save(in_artifact)
         self.runner.invoke(
-            tools, ['cache-store', '--cache-path', str(self.cache.path),
+            tools, ['cache-store', '--cache', str(self.cache.path),
                     '--artifact-path', in_artifact, '--key', 'key'])
 
         result = self.runner.invoke(
-            tools, ['cache-status', '--cache-path', str(self.cache.path)])
+            tools, ['cache-status', '--cache', str(self.cache.path)])
         data_output = 'Data keys in cache:\ndata: key -> %s' % \
             str(Result.peek(self.cache.data / str(self.art1.uuid)))
         success = \
@@ -620,7 +619,7 @@ class TestCacheTools(unittest.TestCase):
         pool.save(self.art2)
 
         result = self.runner.invoke(
-            tools, ['cache-status', '--cache-path', str(self.cache.path)])
+            tools, ['cache-status', '--cache', str(self.cache.path)])
         pool_output = 'Pool keys in cache:\npool: pool_key -> size = 1'
         success = \
             success_template % (str(self.cache.path), data_output,

--- a/q2cli/tests/test_tools.py
+++ b/q2cli/tests/test_tools.py
@@ -472,7 +472,7 @@ class TestCacheTools(unittest.TestCase):
         cache_path = os.path.join(self.tempdir.name, 'created_cache')
 
         result = self.runner.invoke(
-            tools, ['cache-create', '--path', cache_path])
+            tools, ['cache-create', '--cache-path', cache_path])
 
         success = "Created cache at '%s'\n" % cache_path
         self.assertEqual(success, result.output)
@@ -484,7 +484,8 @@ class TestCacheTools(unittest.TestCase):
 
         result = self.runner.invoke(
             tools,
-            ['cache-remove', '--path', str(self.cache.path), '--key', 'key'])
+            ['cache-remove', '--cache-path', str(self.cache.path), '--key',
+             'key'])
 
         success = "Removed key 'key' from cache '%s'\n" % self.cache.path
         self.assertEqual(success, result.output)
@@ -528,7 +529,7 @@ class TestCacheTools(unittest.TestCase):
         gc.collect()
         result = self.runner.invoke(
             tools,
-            ['cache-garbage-collection', '--path', str(self.cache.path)])
+            ['cache-garbage-collection', '--cache-path', str(self.cache.path)])
 
         success = "Ran garbage collection on cache at '%s'\n" % self.cache.path
         self.assertEqual(success, result.output)
@@ -537,24 +538,24 @@ class TestCacheTools(unittest.TestCase):
         post_gc_contents = _get_cache_contents(self.cache)
         self.assertEqual(expected_post_gc_contents, post_gc_contents)
 
-    def test_cache_save(self):
+    def test_cache_store(self):
         artifact = os.path.join(self.tempdir.name, 'artifact.qza')
         self.art1.save(artifact)
 
         result = self.runner.invoke(
-            tools, ['cache-save', '--cache-path', str(self.cache.path),
+            tools, ['cache-store', '--cache-path', str(self.cache.path),
                     '--artifact-path', artifact, '--key', 'key'])
 
         success = "Saved the artifact '%s' to the cache '%s' under the key " \
             "'key'\n" % (artifact, self.cache.path)
         self.assertEqual(success, result.output)
 
-    def test_cache_load(self):
+    def test_cache_fetch(self):
         artifact = os.path.join(self.tempdir.name, 'artifact.qza')
         self.cache.save(self.art1, 'key')
 
         result = self.runner.invoke(
-            tools, ['cache-load', '--cache-path', str(self.cache.path),
+            tools, ['cache-fetch', '--cache-path', str(self.cache.path),
                     '--key', 'key', '--output-path', artifact])
 
         success = "Loaded artifact with the key 'key' from the cache '%s' " \
@@ -568,7 +569,7 @@ class TestCacheTools(unittest.TestCase):
         self.art1.save(in_artifact)
 
         result = self.runner.invoke(
-            tools, ['cache-save', '--cache-path', str(self.cache.path),
+            tools, ['cache-store', '--cache-path', str(self.cache.path),
                     '--artifact-path', in_artifact, '--key', 'key'])
 
         success = "Saved the artifact '%s' to the cache '%s' under the key " \
@@ -576,7 +577,7 @@ class TestCacheTools(unittest.TestCase):
         self.assertEqual(success, result.output)
 
         result = self.runner.invoke(
-            tools, ['cache-load', '--cache-path', str(self.cache.path),
+            tools, ['cache-fetch', '--cache-path', str(self.cache.path),
                     '--key', 'key', '--output-path', out_artifact])
 
         success = "Loaded artifact with the key 'key' from the cache '%s' " \
@@ -592,7 +593,7 @@ class TestCacheTools(unittest.TestCase):
 
         # Empty cache
         result = self.runner.invoke(
-            tools, ['cache-status', '--path', str(self.cache.path)])
+            tools, ['cache-status', '--cache-path', str(self.cache.path)])
         success = \
             success_template % (str(self.cache.path), 'No data keys in cache',
                                 'No pool keys in cache')
@@ -602,11 +603,11 @@ class TestCacheTools(unittest.TestCase):
         in_artifact = os.path.join(self.tempdir.name, 'in_artifact.qza')
         self.art1.save(in_artifact)
         self.runner.invoke(
-            tools, ['cache-save', '--cache-path', str(self.cache.path),
+            tools, ['cache-store', '--cache-path', str(self.cache.path),
                     '--artifact-path', in_artifact, '--key', 'key'])
 
         result = self.runner.invoke(
-            tools, ['cache-status', '--path', str(self.cache.path)])
+            tools, ['cache-status', '--cache-path', str(self.cache.path)])
         data_output = 'Data keys in cache:\ndata: key -> %s' % \
             str(Result.peek(self.cache.data / str(self.art1.uuid)))
         success = \
@@ -619,7 +620,7 @@ class TestCacheTools(unittest.TestCase):
         pool.save(self.art2)
 
         result = self.runner.invoke(
-            tools, ['cache-status', '--path', str(self.cache.path)])
+            tools, ['cache-status', '--cache-path', str(self.cache.path)])
         pool_output = 'Pool keys in cache:\npool: pool_key -> size = 1'
         success = \
             success_template % (str(self.cache.path), data_output,


### PR DESCRIPTION
Renames cache-save/load to cache-store/fetch and standardizes to --cache-path