### PR TITLE
IMP: differentiate stdout between cache entry and file output

### DIFF
--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -381,9 +381,13 @@ class ActionCommand(BaseCommandMixin, click.Command):
                 path = result.save(output)
 
             if not quiet:
-                click.echo(
-                    CONFIG.cfg_style('success', 'Saved %s to: %s' %
-                                     (result.type, path)))
+                if output_in_cache(output):
+                    message = \
+                        f"Added {result.type} to cache: {cache_path} as: {key}"
+                else:
+                    message = f"Saved {result.type} to: {path}"
+
+                click.echo(CONFIG.cfg_style('success', message))
 
     def _order_outputs(self, outputs):
         ordered = []


### PR DESCRIPTION
Changed stdout on action completion to differentiate between artifacts added to a cache and artifacts saved to a standard file. 

See #285.