### PR TITLE
FEAT: qiime tools show-types and qiime tools show-formats commands

### DIFF
--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -151,7 +151,7 @@ def _get_matches(words, possibilities, strict=False):
 def show_types(queries, strict, tsv):
     pm = q2cli.util.get_plugin_manager()
 
-    if queries:
+    if len(queries) > 0:
         matches = _get_matches(queries, list(pm.artifact_classes), strict)
     else:
         matches = sorted(list(pm.artifact_classes))
@@ -191,7 +191,7 @@ def show_formats(queries, importable, exportable, strict, tsv):
     portable_formats = pm.importable_formats if importable \
         else pm.exportable_formats
 
-    if queries:
+    if len(queries) > 0:
         matches = _get_matches(queries, portable_formats.keys(), strict)
     else:
         matches = sorted(portable_formats.keys())

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -114,7 +114,13 @@ def get_matches(words, possibilities, cutoff=0.5):
                                     possibilities, 
                                     n=len(possibilities),
                                     cutoff=cutoff) 
-    return matches
+        # simple substring search 
+        for possibility in possibilities:
+            if word.lower() in possibility.lower() \
+                and possibility not in matches:
+                matches.append(possibility)
+
+    return matches 
 
 
 @tools.command(

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -876,11 +876,13 @@ def cache_status(cache):
             for key in _cache.get_keys():
                 key_values = _cache.read_key(key)
 
-                if (data := key_values['data']) is not None:
+                if 'data' in key_values:
+                    data = key_values['data']
                     data_output.append(
                         'data: %s -> %s' %
                         (key, str(Result.peek(_cache.data / data))))
-                elif (pool := key_values['pool']) is not None:
+                elif 'pool' in key_values:
+                    pool = key_values['pool']
                     pool_output.append(
                         'pool: %s -> size = %s' %
                         (key, str(len(os.listdir(_cache.pools / pool)))))

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -207,17 +207,22 @@ def show_formats(formats, importable, exportable, strict, tsv):
 
 
 def show_importable_types(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
     click.secho('This functionality has been moved to the show-types command.',
                 fg='red', bold=True)
-    click.secho('Run `qiime tools show-types` for more information.',
+    click.secho('Run `qiime tools show-types --help` for more information.',
                 fg='red', bold=True)
-    return
+    ctx.exit()
 
 def show_importable_formats(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
     click.secho('This functionality has been moved to the show-formats '
                 'command.', fg='red', bold=True)
-    click.secho('Run `qiime tools show-formats` for more information.',
+    click.secho('Run `qiime tools show-formats --help` for more information.',
                 fg='red', bold=True)
+    ctx.exit()
 
 @tools.command(name='import',
                short_help='Import data into a new QIIME 2 Artifact.',

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -176,8 +176,9 @@ def show_formats(formats, importable, exportable, strict, tsv):
                                "is required.")
 
     pm = q2cli.util.get_plugin_manager()
-    available_formats = list(pm.importable_formats) if importable \
-        else list(pm.exportable_formats)
+    portable_formats = pm.importable_formats if importable \
+        else pm.exportable_formats 
+    available_formats = list(portable_formats)
 
     if formats and strict:
         matches = get_matches(formats, available_formats, 1)
@@ -188,7 +189,7 @@ def show_formats(formats, importable, exportable, strict, tsv):
 
     descriptions = {}
     for match in sorted(matches):
-        docstring = pm.importable_formats[match].format.__doc__
+        docstring = portable_formats[match].format.__doc__
         first_docstring_line = docstring.split('\n\n')[0].strip() \
             if docstring else ''
         descriptions[match] = first_docstring_line

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -85,7 +85,7 @@ def print_descriptions(descriptions, tsv):
         for value, description in descriptions.items():
             click.echo(f"{value}\t", nl=False)
             if description:
-                click.echo(description)
+                click.echo(deformat_description(description))
             else:
                 click.echo()
     else:
@@ -93,6 +93,7 @@ def print_descriptions(descriptions, tsv):
         for value, description in descriptions.items():
             click.secho(value, bold=True)
             if description:
+                description = deformat_description(description)
                 tabsize = 8
                 wrapped_description = textwrap.wrap(description,
                                                     width=72-tabsize,
@@ -105,6 +106,11 @@ def print_descriptions(descriptions, tsv):
                 click.secho("\tNo description", italic=True)
             click.echo()
 
+def deformat_description(description):
+    import re
+    deformatted = re.sub(r"[\t\n]+", ' ', description) 
+    despaced = re.sub(r" +", ' ', deformatted)
+    return despaced
 
 def get_matches(words, possibilities, cutoff=0.5):
     from difflib import get_close_matches

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -80,7 +80,6 @@ def export_data(input_path, output_path, output_format):
     click.echo(CONFIG.cfg_style('success', success))
 
 
-
 def print_descriptions(descriptions, tsv):
     if tsv:
         for value, description in descriptions.items():
@@ -95,9 +94,9 @@ def print_descriptions(descriptions, tsv):
             click.secho(value, bold=True)
             if description:
                 tabsize = 8
-                wrapped_description = textwrap.wrap(description, 
-                                                    width=72-tabsize, 
-                                                    initial_indent='\t', 
+                wrapped_description = textwrap.wrap(description,
+                                                    width=72-tabsize,
+                                                    initial_indent='\t',
                                                     subsequent_indent='\t',
                                                     tabsize=tabsize)
                 for line in wrapped_description:
@@ -106,21 +105,22 @@ def print_descriptions(descriptions, tsv):
                 click.secho("\tNo description", italic=True)
             click.echo()
 
+
 def get_matches(words, possibilities, cutoff=0.5):
     from difflib import get_close_matches
     matches = []
     for word in words:
-        matches += get_close_matches(word, 
-                                    possibilities, 
-                                    n=len(possibilities),
-                                    cutoff=cutoff) 
-        # simple substring search 
+        matches += get_close_matches(word,
+                                     possibilities,
+                                     n=len(possibilities),
+                                     cutoff=cutoff)
+        # simple substring search
         for possibility in possibilities:
-            if word.lower() in possibility.lower() \
-                and possibility not in matches:
-                matches.append(possibility)
+            if word.lower() in possibility.lower():
+                if possibility not in matches:
+                    matches.append(possibility)
 
-    return matches 
+    return matches
 
 
 @tools.command(
@@ -151,6 +151,7 @@ def show_types(types, strict, tsv):
 
     print_descriptions(descriptions, tsv)
 
+
 @tools.command(
         name='show-formats',
         help='List the availabe formats.',
@@ -158,9 +159,9 @@ def show_types(types, strict, tsv):
         cls=ToolCommand
 )
 @click.argument('formats', nargs=-1)
-@click.option('--importable', is_flag=True, 
+@click.option('--importable', is_flag=True,
               help='List the importable formats.')
-@click.option('--exportable', is_flag=True, 
+@click.option('--exportable', is_flag=True,
               help='List the exportable formats.')
 @click.option('--strict', is_flag=True,
               help='Show only exact matches for the format argument(s).')
@@ -176,24 +177,23 @@ def show_formats(formats, importable, exportable, strict, tsv):
 
     pm = q2cli.util.get_plugin_manager()
     available_formats = list(pm.importable_formats) if importable \
-                        else list(pm.exportable_formats)
+        else list(pm.exportable_formats)
 
     if formats and strict:
         matches = get_matches(formats, available_formats, 1)
     elif formats:
         matches = get_matches(formats, available_formats)
     else:
-        matches = available_formats    
+        matches = available_formats
 
     descriptions = {}
     for match in sorted(matches):
-        docstring = pm.importable_formats[match].format.__doc__ 
+        docstring = pm.importable_formats[match].format.__doc__
         first_docstring_line = docstring.split('\n\n')[0].strip() \
-                               if docstring else ''
+            if docstring else ''
         descriptions[match] = first_docstring_line
 
     print_descriptions(descriptions, tsv)
-
 
 
 def show_importable_types(ctx, param, value):

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -79,6 +79,51 @@ def export_data(input_path, output_path, output_format):
                                               output_type, output_path)
     click.echo(CONFIG.cfg_style('success', success))
 
+@tools.command(name='show-importable',
+               help='Show the semantic types or directory formats that '
+                    'are available to be imported into an artifact. ',
+               cls=ToolCommand)
+@click.option('--semantic-types', is_flag=True,
+              help='List the importable semantic types.')
+@click.option('--formats', is_flag=True,
+              help='List the importable formats.')
+@click.option('--tsv', is_flag=True,
+              help='Print as machine-readable tab separated values.')
+def show_importable(semantic_types, formats, tsv):
+    import textwrap
+    pm = q2cli.util.get_plugin_manager()
+    if semantic_types:
+        for importable_type in sorted(list(pm.importable_types)):
+            description = pm.artifact_classes[importable_type].description
+            click.secho(importable_type, bold=True)
+            if description:
+                tabsize = 8
+                wrapped_description = textwrap.wrap(description, 
+                                                    width=72-tabsize, 
+                                                    initial_indent='\t', 
+                                                    subsequent_indent='\t',
+                                                    tabsize=tabsize)
+                for line in wrapped_description:
+                    click.echo(f"{line}")
+            else:
+                click.secho("\tNo description", italic=True)
+            click.echo()
+            
+    elif formats:
+       for format in sorted(list(pm.importable_formats)):
+           click.secho(format) 
+           print(type(format))
+
+    else:
+        ctx = click.get_current_context()
+        click.echo(ctx.get_help())
+        click.secho('\n\t\tThere was a problem with the command:', 
+                    fg='yellow')
+        click.secho('\n  One of the following flags is required:', bold=True,
+                    fg="red")
+        click.secho("\t'--semantic-types' (or)", bold=True, fg='red')
+        click.secho("\t'--formats'", bold=True, fg='red')
+
 
 def show_importable_types(ctx, param, value):
     if not value or ctx.resilient_parsing:

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -207,41 +207,17 @@ def show_formats(formats, importable, exportable, strict, tsv):
 
 
 def show_importable_types(ctx, param, value):
-    if not value or ctx.resilient_parsing:
-        return
-
-    import q2cli.util
-
-    importable_types = sorted(q2cli.util.get_plugin_manager().importable_types,
-                              key=repr)
-
-    if importable_types:
-        for name in importable_types:
-            click.echo(name)
-    else:
-        click.echo('There are no importable types in the current deployment.')
-
-    ctx.exit()
-
+    click.secho('This functionality has been moved to the show-types command.',
+                fg='red', bold=True)
+    click.secho('Run `qiime tools show-types` for more information.',
+                fg='red', bold=True)
+    return
 
 def show_importable_formats(ctx, param, value):
-    if not value or ctx.resilient_parsing:
-        return
-
-    import q2cli.util
-
-    importable_formats = sorted(
-            q2cli.util.get_plugin_manager().importable_formats)
-
-    if importable_formats:
-        for format in importable_formats:
-            click.echo(format)
-    else:
-        click.echo('There are no importable formats '
-                   'in the current deployment.')
-
-    ctx.exit()
-
+    click.secho('This functionality has been moved to the show-formats '
+                'command.', fg='red', bold=True)
+    click.secho('Run `qiime tools show-formats` for more information.',
+                fg='red', bold=True)
 
 @tools.command(name='import',
                short_help='Import data into a new QIIME 2 Artifact.',

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -215,6 +215,7 @@ def show_importable_types(ctx, param, value):
                 fg='red', bold=True)
     ctx.exit()
 
+
 def show_importable_formats(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
@@ -223,6 +224,7 @@ def show_importable_formats(ctx, param, value):
     click.secho('Run `qiime tools show-formats --help` for more information.',
                 fg='red', bold=True)
     ctx.exit()
+
 
 @tools.command(name='import',
                short_help='Import data into a new QIIME 2 Artifact.',

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -120,11 +120,12 @@ def get_matches(words, possibilities, cutoff=0.5):
                                      possibilities,
                                      n=len(possibilities),
                                      cutoff=cutoff)
-        # simple substring search
-        for possibility in possibilities:
-            if word.lower() in possibility.lower():
-                if possibility not in matches:
-                    matches.append(possibility)
+        # substring search
+        if cutoff != 1:
+            for possibility in possibilities:
+                if word.lower() in possibility.lower():
+                    if possibility not in matches:
+                        matches.append(possibility)
 
     return matches
 

--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -106,11 +106,13 @@ def print_descriptions(descriptions, tsv):
                 click.secho("\tNo description", italic=True)
             click.echo()
 
+
 def deformat_description(description):
     import re
-    deformatted = re.sub(r"[\t\n]+", ' ', description) 
+    deformatted = re.sub(r"[\t\n]+", ' ', description)
     despaced = re.sub(r" +", ' ', deformatted)
     return despaced
+
 
 def get_matches(words, possibilities, cutoff=0.5):
     from difflib import get_close_matches
@@ -184,7 +186,7 @@ def show_formats(formats, importable, exportable, strict, tsv):
 
     pm = q2cli.util.get_plugin_manager()
     portable_formats = pm.importable_formats if importable \
-        else pm.exportable_formats 
+        else pm.exportable_formats
     available_formats = list(portable_formats)
 
     if formats and strict:

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -381,9 +381,13 @@ class ActionCommand(BaseCommandMixin, click.Command):
                 path = result.save(output)
 
             if not quiet:
-                click.echo(
-                    CONFIG.cfg_style('success', 'Saved %s to: %s' %
-                                     (result.type, path)))
+                if output_in_cache(output):
+                    message = \
+                        f"Added {result.type} to cache: {cache_path} as: {key}"
+                else:
+                    message = f"Saved {result.type} to: {path}"
+
+                click.echo(CONFIG.cfg_style('success', message))
 
     def _order_outputs(self, outputs):
         ordered = []

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -381,13 +381,9 @@ class ActionCommand(BaseCommandMixin, click.Command):
                 path = result.save(output)
 
             if not quiet:
-                if output_in_cache(output):
-                    message = \
-                        f"Added {result.type} to cache: {cache_path} as: {key}"
-                else:
-                    message = f"Saved {result.type} to: {path}"
-
-                click.echo(CONFIG.cfg_style('success', message))
+                click.echo(
+                    CONFIG.cfg_style('success', 'Saved %s to: %s' %
+                                     (result.type, path)))
 
     def _order_outputs(self, outputs):
         ordered = []

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -93,30 +93,6 @@ class CliTests(unittest.TestCase):
             '10', '--output-dir', output_dir, '--verbose'])
         self.assertEqual(result.exit_code, 0)
 
-    def test_show_importable_types(self):
-        result = self.runner.invoke(
-            tools, ['import', '--show-importable-types'])
-        self.assertEqual(result.exit_code, 0)
-        self.assertIn('FourInts', result.output)
-        self.assertIn('IntSequence1', result.output)
-        self.assertIn('IntSequence2', result.output)
-        self.assertIn('Kennel[Cat]', result.output)
-        self.assertIn('Kennel[Dog]', result.output)
-        self.assertIn('Mapping', result.output)
-
-    def test_show_importable_formats(self):
-        result = self.runner.invoke(
-            tools, ['import', '--show-importable-formats'])
-        self.assertEqual(result.exit_code, 0)
-        self.assertIn('FourIntsDirectoryFormat', result.output)
-        self.assertIn('IntSequenceDirectoryFormat', result.output)
-        self.assertNotIn('UnimportableFormat', result.output)
-        self.assertNotIn('UnimportableDirectoryFormat', result.output)
-        self.assertIn('MappingDirectoryFormat', result.output)
-        self.assertIn('IntSequenceFormat', result.output)
-        self.assertIn('IntSequenceFormatV2', result.output)
-        self.assertIn('IntSequenceV2DirectoryFormat', result.output)
-
     def test_extract(self):
         result = self.runner.invoke(
             tools, ['extract', '--input-path', self.artifact1_path,

--- a/q2cli/tests/test_tools.py
+++ b/q2cli/tests/test_tools.py
@@ -725,7 +725,7 @@ class TestPeek(unittest.TestCase):
         self.assertEqual(result.output.count('\n'), 3)
 
 
-class TestShowTypes(unittest.TestCase):
+class TestListTypes(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()
         self.pm = PluginManager()
@@ -733,17 +733,17 @@ class TestShowTypes(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_show_all_types(self):
-        result = self.runner.invoke(tools, ['show-types'])
+    def test_list_all_types(self):
+        result = self.runner.invoke(tools, ['list-types'])
         self.assertEqual(result.exit_code, 0)
 
         for name, artifact_class_record in self.pm.artifact_classes.items():
             self.assertIn(name, result.output)
             self.assertIn(artifact_class_record.description, result.output)
 
-    def test_show_types_fuzzy(self):
+    def test_list_types_fuzzy(self):
         types = list(self.pm.artifact_classes)[:5]
-        result = self.runner.invoke(tools, ['show-types', *types])
+        result = self.runner.invoke(tools, ['list-types', *types])
         self.assertEqual(result.exit_code, 0)
 
         # split on \n\n because types and their description are separated
@@ -752,24 +752,24 @@ class TestShowTypes(unittest.TestCase):
         self.assertGreaterEqual(len(result.output.split('\n\n')) - 1,
                                 len(types))
 
-    def test_show_types_strict(self):
+    def test_list_types_strict(self):
         types = list(self.pm.artifact_classes)[:5]
-        result = self.runner.invoke(tools, ['show-types', '--strict', *types])
+        result = self.runner.invoke(tools, ['list-types', '--strict', *types])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(len(result.output.split('\n\n')) - 1, len(types))
 
-        result = self.runner.invoke(tools, ['show-types', '--strict',
+        result = self.runner.invoke(tools, ['list-types', '--strict',
                                             'nonsense', 'morenonesense'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(len(result.output), 0)
 
-        result = self.runner.invoke(tools, ['show-types', '--strict', *types,
+        result = self.runner.invoke(tools, ['list-types', '--strict', *types,
                                             'nonsense', 'morenonesense'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(len(result.output.split('\n\n')) - 1, len(types))
 
-    def test_show_types_tsv(self):
-        result = self.runner.invoke(tools, ['show-types', '--tsv'])
+    def test_list_types_tsv(self):
+        result = self.runner.invoke(tools, ['list-types', '--tsv'])
         self.assertEqual(result.exit_code, 0)
 
         # len - 1 because \n split produces a final ''
@@ -786,7 +786,7 @@ class TestShowTypes(unittest.TestCase):
         self.assertEqual(no_description_count, result.output.count('\t\n'))
 
 
-class TestShowFormats(unittest.TestCase):
+class TestListFormats(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()
         self.pm = PluginManager()
@@ -794,8 +794,8 @@ class TestShowFormats(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_show_all_importable_formats(self):
-        result = self.runner.invoke(tools, ['show-formats', '--importable'])
+    def test_list_all_importable_formats(self):
+        result = self.runner.invoke(tools, ['list-formats', '--importable'])
         self.assertEqual(result.exit_code, 0)
 
         for name, format_record in self.pm.importable_formats.items():
@@ -806,8 +806,8 @@ class TestShowFormats(unittest.TestCase):
                 for word in description:
                     self.assertIn(word.strip(), result.output)
 
-    def test_show_all_exportable_formats(self):
-        result = self.runner.invoke(tools, ['show-formats', '--exportable'])
+    def test_list_all_exportable_formats(self):
+        result = self.runner.invoke(tools, ['list-formats', '--exportable'])
         self.assertEqual(result.exit_code, 0)
 
         for name, format_record in self.pm.exportable_formats.items():
@@ -818,39 +818,39 @@ class TestShowFormats(unittest.TestCase):
                 for word in description:
                     self.assertIn(word.strip(), result.output)
 
-    def test_show_formats_fuzzy(self):
+    def test_list_formats_fuzzy(self):
         formats = list(self.pm.importable_formats)[:5]
-        result = self.runner.invoke(tools, ['show-formats', '--importable',
+        result = self.runner.invoke(tools, ['list-formats', '--importable',
                                             *formats])
         self.assertEqual(result.exit_code, 0)
 
-        # see TestShowTypes.test_show_types_fuzzy
+        # see TestListTypes.test_list_types_fuzzy
         self.assertGreaterEqual(len(result.output.split('\n\n')) - 1,
                                 len(formats))
 
-    def test_show_formats_strict(self):
+    def test_list_formats_strict(self):
         formats = list(self.pm.exportable_formats)[:5]
-        result = self.runner.invoke(tools, ['show-formats', '--exportable',
+        result = self.runner.invoke(tools, ['list-formats', '--exportable',
                                             '--strict', *formats])
         self.assertEqual(result.exit_code, 0)
         print(formats)
         print(result.output)
         self.assertEqual(len(result.output.split('\n\n')) - 1, len(formats))
 
-        result = self.runner.invoke(tools, ['show-formats', '--exportable',
+        result = self.runner.invoke(tools, ['list-formats', '--exportable',
                                             '--strict', 'nonsense',
                                             'morenonesense'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(len(result.output), 0)
 
-        result = self.runner.invoke(tools, ['show-formats', '--exportable',
+        result = self.runner.invoke(tools, ['list-formats', '--exportable',
                                             '--strict', *formats, 'nonsense',
                                             'morenonesense'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(len(result.output.split('\n\n')) - 1, len(formats))
 
-    def test_show_formats_tsv(self):
-        result = self.runner.invoke(tools, ['show-formats', '--importable',
+    def test_list_formats_tsv(self):
+        result = self.runner.invoke(tools, ['list-formats', '--importable',
                                             '--tsv'])
         self.assertEqual(result.exit_code, 0)
 

--- a/q2cli/tests/test_tools.py
+++ b/q2cli/tests/test_tools.py
@@ -759,12 +759,12 @@ class TestListTypes(unittest.TestCase):
         self.assertEqual(len(result.output.split('\n\n')) - 1, len(types))
 
         result = self.runner.invoke(tools, ['list-types', '--strict',
-                                            'nonsense', 'morenonesense'])
+                                            types[0] + 'x'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(len(result.output), 0)
 
         result = self.runner.invoke(tools, ['list-types', '--strict', *types,
-                                            'nonsense', 'morenonesense'])
+                                            types[0] + 'x'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(len(result.output.split('\n\n')) - 1, len(types))
 
@@ -838,14 +838,13 @@ class TestListFormats(unittest.TestCase):
         self.assertEqual(len(result.output.split('\n\n')) - 1, len(formats))
 
         result = self.runner.invoke(tools, ['list-formats', '--exportable',
-                                            '--strict', 'nonsense',
-                                            'morenonesense'])
+                                            '--strict', formats[0] + 'x'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(len(result.output), 0)
 
         result = self.runner.invoke(tools, ['list-formats', '--exportable',
-                                            '--strict', *formats, 'nonsense',
-                                            'morenonesense'])
+                                            '--strict', *formats,
+                                            formats[0] + 'x'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(len(result.output.split('\n\n')) - 1, len(formats))
 


### PR DESCRIPTION
Added two commands to show the available semantic types and importable and exportable formats for a qiime deployment. 

Will replace the functionality of the `qiime tools import --show-importable-types` and `qiime tools import --show-importable-formats` commands.

Additionally:
- descriptions are given of each semantic type or format when available
- semantic types or formats can be subsetted to only those of interest 
- a `--tsv` flag is available

Motivated by #289.