### PR TITLE
Hide actions that start with _ and have flag to show them

### DIFF
--- a/q2cli/click/command.py
+++ b/q2cli/click/command.py
@@ -41,6 +41,7 @@ class BaseCommandMixin:
         from q2cli.core.config import CONFIG
         if isinstance(self, click.MultiCommand):
             return super().parse_args(ctx, args)
+
         errors = []
         parser = self.make_parser(ctx)
         skip_rest = False

--- a/q2cli/click/command.py
+++ b/q2cli/click/command.py
@@ -41,7 +41,6 @@ class BaseCommandMixin:
         from q2cli.core.config import CONFIG
         if isinstance(self, click.MultiCommand):
             return super().parse_args(ctx, args)
-
         errors = []
         parser = self.make_parser(ctx)
         skip_rest = False

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -158,7 +158,7 @@ class PluginCommand(BaseCommandMixin, click.MultiCommand):
                     help="This plugin has hidden actions with names starting "
                          "with '_'. These are generally called internally by "
                          "pipelines. Passing this flag will display those "
-                         "methods."))
+                         "actions."))
 
         super().__init__(name, *args, short_help=plugin['short_description'],
                          help=help_, params=params, **kwargs)

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -221,6 +221,8 @@ class PluginCommand(BaseCommandMixin, click.MultiCommand):
 
     def get_command(self, ctx, name):
         try:
+            # Hidden actions are still valid commands
+            self._action_lookup.update(self._hidden_actions)
             action = self._action_lookup[name]
         except KeyError:
             from q2cli.util import get_close_matches

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -146,12 +146,19 @@ class PluginCommand(BaseCommandMixin, click.MultiCommand):
                          is_eager=True, callback=self._get_version,
                          help='Show the version and exit.'),
             q2cli.util.example_data_option(self._get_plugin),
-            q2cli.util.citations_option(self._get_citation_records),
-            click.Option(('--show-hidden-actions',), is_flag=True,
-                         expose_value=False, is_eager=True,
-                         callback=self._get_hidden_actions,
-                         help='Show hidden actions in the actions list.')
+            q2cli.util.citations_option(self._get_citation_records)
         ]
+
+        if self._hidden_actions is not {}:
+            params.append(
+                click.Option(
+                    ('--show-hidden-actions',), is_flag=True,
+                    expose_value=False, is_eager=True,
+                    callback=self._get_hidden_actions,
+                    help="This plugin has hidden actions with names starting "
+                         "with '_'. These are generally called internally by "
+                         "pipelines. Passing this flag will display those "
+                         "methods."))
 
         super().__init__(name, *args, short_help=plugin['short_description'],
                          help=help_, params=params, **kwargs)

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -136,10 +136,6 @@ class PluginCommand(BaseCommandMixin, click.MultiCommand):
             else:
                 self._action_lookup[q2cli.util.to_cli_name(id)] = a
 
-        self._action_lookup = {q2cli.util.to_cli_name(id): a for id, a in
-                               plugin['actions'].items()
-                               if not id.startswith('_')}
-
         support = 'Getting user support: %s' % plugin['user_support_text']
         website = 'Plugin website: %s' % plugin['website']
         description = 'Description: %s' % plugin['description']

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -179,10 +179,18 @@ class PluginCommand(BaseCommandMixin, click.MultiCommand):
     def _get_hidden_actions(self, ctx, param, value):
         # Add actions that start with _ back to the lookup. Do not replace the
         # starting _ with -
+        from click.utils import echo
+
         self._action_lookup.update(
             {q2cli.util.to_cli_name(id).replace('-', '_', 1): a
              for id, a in self._plugin['actions'].items()
              if id.startswith('_')})
+
+        # Handle the printing and exiting here. This feels like a pretty
+        # serious misuse of click, but it probably isn't the most egregious in
+        # the cli
+        echo(ctx.get_help(), color=ctx.color)
+        ctx.exit()
 
     def _get_plugin(self):
         import q2cli.util

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -149,7 +149,7 @@ class PluginCommand(BaseCommandMixin, click.MultiCommand):
             q2cli.util.citations_option(self._get_citation_records)
         ]
 
-        if self._hidden_actions is not {}:
+        if self._hidden_actions != {}:
             params.append(
                 click.Option(
                     ('--show-hidden-actions',), is_flag=True,

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -87,6 +87,7 @@ class CliTests(unittest.TestCase):
 
         self.assertNotIn('split_ints', commands)
         self.assertNotIn('mapping_viz', commands)
+        self.assertNotIn('_underscore_method', commands)
         self.assertNotIn('-underscore-method', commands)
 
     def test_action_parameter_types(self):

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -84,6 +84,8 @@ class CliTests(unittest.TestCase):
         self.assertIn('mapping-viz', results)
         self.assertIn('_underscore-method', results)
 
+        self.assertNotIn('split_ints', results)
+        self.assertNotIn('mapping_viz', results)
         self.assertNotIn('-underscore-method', results)
 
     def test_action_parameter_types(self):

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -111,6 +111,16 @@ class CliTests(unittest.TestCase):
             '10', '--output-dir', output_dir, '--verbose'])
         self.assertEqual(result.exit_code, 0)
 
+    def test_execute_hidden_action(self):
+        int_path = os.path.join(self.tempdir, 'int.qza')
+        qiime_cli = RootCommand()
+        command = qiime_cli.get_command(ctx=None, name='dummy-plugin')
+        result = self.runner.invoke(
+                command, ['_underscore-method', '--o-int', int_path,
+                          '--verbose'])
+
+        self.assertEqual(result.exit_code, 0)
+
     def test_extract(self):
         result = self.runner.invoke(
             tools, ['extract', '--input-path', self.artifact1_path,

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -79,14 +79,15 @@ class CliTests(unittest.TestCase):
         # hidden method
         qiime_cli = RootCommand('--show-hidden-actions')
         command = qiime_cli.get_command(ctx=None, name='dummy-plugin')
-        results = self.runner.invoke(command, ['--show-hidden-actions']).output
-        self.assertIn('split-ints', results)
-        self.assertIn('mapping-viz', results)
-        self.assertIn('_underscore-method', results)
+        commands = self.runner.invoke(command,
+                                      ['--show-hidden-actions']).output
+        self.assertIn('split-ints', commands)
+        self.assertIn('mapping-viz', commands)
+        self.assertIn('_underscore-method', commands)
 
-        self.assertNotIn('split_ints', results)
-        self.assertNotIn('mapping_viz', results)
-        self.assertNotIn('-underscore-method', results)
+        self.assertNotIn('split_ints', commands)
+        self.assertNotIn('mapping_viz', commands)
+        self.assertNotIn('-underscore-method', commands)
 
     def test_action_parameter_types(self):
         qiime_cli = RootCommand()

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -77,7 +77,7 @@ class CliTests(unittest.TestCase):
     def test_plugin_list_hidden_commands(self):
         # plugin commands are present including a method and visualizer and
         # hidden method
-        qiime_cli = RootCommand('--show-hidden-actions')
+        qiime_cli = RootCommand()
         command = qiime_cli.get_command(ctx=None, name='dummy-plugin')
         commands = self.runner.invoke(command,
                                       ['--show-hidden-actions']).output

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -71,6 +71,20 @@ class CliTests(unittest.TestCase):
 
         self.assertFalse('split_ints' in commands)
         self.assertFalse('mapping_viz' in commands)
+        self.assertNotIn('-underscore-method', commands)
+        self.assertNotIn('_underscore-method', commands)
+
+    def test_plugin_list_hidden_commands(self):
+        # plugin commands are present including a method and visualizer and
+        # hidden method
+        qiime_cli = RootCommand('--show-hidden-actions')
+        command = qiime_cli.get_command(ctx=None, name='dummy-plugin')
+        results = self.runner.invoke(command, ['--show-hidden-actions']).output
+        self.assertIn('split-ints', results)
+        self.assertIn('mapping-viz', results)
+        self.assertIn('_underscore-method', results)
+
+        self.assertNotIn('-underscore-method', results)
 
     def test_action_parameter_types(self):
         qiime_cli = RootCommand()

--- a/q2cli/tests/test_cli.py
+++ b/q2cli/tests/test_cli.py
@@ -69,8 +69,8 @@ class CliTests(unittest.TestCase):
         self.assertIn('split-ints', commands)
         self.assertIn('mapping-viz', commands)
 
-        self.assertFalse('split_ints' in commands)
-        self.assertFalse('mapping_viz' in commands)
+        self.assertNotIn('split_ints', commands)
+        self.assertNotIn('mapping_viz', commands)
         self.assertNotIn('-underscore-method', commands)
         self.assertNotIn('_underscore-method', commands)
 

--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -38,7 +38,11 @@ def get_completion_path():
 
 def hidden_to_cli_name(name):
     # Safety first
-    assert name.startswith('_')
+    if not name.startswith('_'):
+        raise ValueError(f"The name '{name}' does not start with '_' meaning"
+                         " it is not a hidden action and this method should"
+                         " not have been called on it.")
+
     name = to_cli_name(name)
 
     # Retain the leading _

--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -37,7 +37,10 @@ def get_completion_path():
 
 
 def hidden_to_cli_name(name):
+    # Safety first
+    assert name.startswith('_')
     name = to_cli_name(name)
+
     # Retain the leading _
     return name.replace('-', '_', 1)
 

--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -36,6 +36,12 @@ def get_completion_path():
     return os.path.join(get_cache_dir(), 'completion.sh')
 
 
+def hidden_to_cli_name(name):
+    name = to_cli_name(name)
+    # Retain the leading _
+    return name.replace('-', '_', 1)
+
+
 def to_cli_name(name):
     return name.replace('_', '-')
 


### PR DESCRIPTION
Closes #301. Hides actions that start with '_' by default and adds a flag to display them.

~~For click related reasons that I do not fully understand yet, this does not work and passing the command results in `Error: Missing Command`  think I more or less understand why it's happening, but I don't have a good solution for the issue yet.~~

Should be gtg now.
