### PR TITLE
MAINT: Ensure we use the proper cache when no_recycle set

### DIFF
--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -535,19 +535,20 @@ class ActionCommand(BaseCommandMixin, click.Command):
 
     def _execute_action(self, action, arguments, recycle_pool=None,
                         cache=None):
-        if recycle_pool is None:
-            results = action(**arguments)
-            results = results._result()
-        else:
-            pool = cache.create_pool(key=recycle_pool, reuse=True)
-            with pool:
+        with cache:
+            if recycle_pool is None:
                 results = action(**arguments)
-
-                # If we executed in a pool using parsl we need to get
-                # our results inside of the context manager to ensure
-                # that the pool is set for the entirety of the
-                # execution
                 results = results._result()
+            else:
+                pool = cache.create_pool(key=recycle_pool, reuse=True)
+                with pool:
+                    results = action(**arguments)
+
+                    # If we executed in a pool using parsl we need to get
+                    # our results inside of the context manager to ensure
+                    # that the pool is set for the entirety of the
+                    # execution
+                    results = results._result()
 
         return results
 

--- a/q2cli/commands.py
+++ b/q2cli/commands.py
@@ -473,10 +473,10 @@ class ActionCommand(BaseCommandMixin, click.Command):
 
                     with parallel_config:
                         results = self._execute_action(
-                            action, arguments, recycle_pool, cache)
+                            action, arguments, cache, recycle_pool)
                 else:
                     results = self._execute_action(
-                        action, arguments, recycle_pool, cache)
+                        action, arguments, cache, recycle_pool)
         except Exception as e:
             header = ('Plugin error from %s:'
                       % q2cli.util.to_cli_name(self.plugin['name']))
@@ -533,8 +533,7 @@ class ActionCommand(BaseCommandMixin, click.Command):
         if recycle_pool == default_pool:
             cache.remove(recycle_pool)
 
-    def _execute_action(self, action, arguments, recycle_pool=None,
-                        cache=None):
+    def _execute_action(self, action, arguments, cache, recycle_pool=None):
         with cache:
             if recycle_pool is None:
                 results = action(**arguments)


### PR DESCRIPTION
Fixes a bug where using `--no-recycle` and `--use-cache` would cause the set cache to not be used,
