### PR TITLE
TST: fix roundtrip on /bin/sh

### DIFF
--- a/q2cli/tests/test_usage.py
+++ b/q2cli/tests/test_usage.py
@@ -193,7 +193,7 @@ def test_round_trip(action, example):
     with tempfile.TemporaryDirectory() as tmpdir:
         for ref, data in use.get_example_data():
             data.save(os.path.join(tmpdir, ref))
-        subprocess.run([rendered],
+        subprocess.run(rendered,
                        shell=True,
                        check=True,
                        cwd=tmpdir,

--- a/q2cli/tests/test_usage.py
+++ b/q2cli/tests/test_usage.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import os
+import sys
 import subprocess
 import tempfile
 import unittest
@@ -190,6 +191,11 @@ def test_round_trip(action, example):
     use = CLIUsage(enable_assertions=True)
     example_f(use)
     rendered = use.render()
+    if sys.platform.startswith('linux'):
+        # TODO: remove me when arrays are not used in shell
+        extra = dict(executable='/bin/bash')
+    else:
+        extra = dict()
     with tempfile.TemporaryDirectory() as tmpdir:
         for ref, data in use.get_example_data():
             data.save(os.path.join(tmpdir, ref))
@@ -197,7 +203,8 @@ def test_round_trip(action, example):
                        shell=True,
                        check=True,
                        cwd=tmpdir,
-                       env={**os.environ})
+                       env={**os.environ},
+                       **extra)
 
 
 class ReplayResultCollectionTests(unittest.TestCase):


### PR DESCRIPTION
I believe we're running into an issue with the format of the subprocess run when testing with the new collection stuff:
https://github.com/qiime2/distributions/actions/runs/7281173631/job/19841955368?pr=62#step:8:267.

This change will _probably_ fix the issue, as shell=True is usually intended to be done with a single string. It hasn't come up as an issue but I think the new collection syntax is finally making it break (in /bin/sh only, bash works fine, hence not seeing it locally).