### PR TITLE
Use New Key Validator

### DIFF
--- a/q2cli/tests/test_cache_cli.py
+++ b/q2cli/tests/test_cache_cli.py
@@ -730,8 +730,8 @@ class TestCacheCli(unittest.TestCase):
         art2_path = str(self.cache.path) + ':art2'
         art3_path = str(self.cache.path) + ':art3'
 
-        out_path = str(self.cache.path) + ':not_valid_identifier$&;'
-
+        invalid = 'not_valid_identifier$&;'
+        out_path = str(self.cache.path) + ':' + invalid
         result = self._run_command(
             'concatenate-ints', '--i-ints1', art1_path, '--i-ints2', art2_path,
             '--i-ints3', art3_path, '--p-int1', '9', '--p-int2', '10',
@@ -739,7 +739,7 @@ class TestCacheCli(unittest.TestCase):
         )
 
         self.assertEqual(result.exit_code, 1)
-        self.assertIn('Keys must be valid Python identifiers',
+        self.assertIn(f"Key '{invalid}' is not a valid Python identifier",
                       str(result.exception))
 
     def test_artifact_as_metadata_cache(self):

--- a/q2cli/util.py
+++ b/q2cli/util.py
@@ -107,14 +107,8 @@ def output_in_cache(fp):
 
     try:
         if Cache.is_cache(cache_path):
-            if not key.isidentifier():
-                raise ValueError(
-                    f"Key '{key}' is not a valid Python identifier. Keys must "
-                    "be valid Python identifiers. Python identifier rules may "
-                    "be found here https://www.askpython.com/python/"
-                    "python-identifiers-rules-best-practices")
-            else:
-                return True
+            Cache.validate_key(key)
+            return True
     except FileNotFoundError as e:
         # If cache_path doesn't exist, don't treat this as a cache output
         if 'No such file or directory' in str(e):


### PR DESCRIPTION
Due to an oversight and some duplicated code, it wasn't possible to make output cache keys on the cli kebab-case. This rectifies that by using the same key validation code from the framework. It is tested [here](https://github.com/qiime2/qiime2/blob/d56401b26a2230a9acbba2ec3a8b398e52e934b5/qiime2/core/tests/test_cache.py#L219) in the framework.

Blocked by qiime2/qiime2#753
