### PR TITLE
update parallel configuration reference link

### DIFF
--- a/q2cli/builtin/info.py
+++ b/q2cli/builtin/info.py
@@ -83,9 +83,6 @@ def info(config_level):
     click.secho('\nGetting help', fg='green')
     click.secho('To get help with QIIME 2, visit https://qiime2.org')
 
-    # TODO: When we have user documentation on parallel QIIME 2 live,
-    # replace this with a reference to our docs which will reference the parsl
-    # docs.
     if config_level:
         click.secho('To get help with configuring and/or understanding '
                     'QIIME 2 parallelization, visit '

--- a/q2cli/builtin/info.py
+++ b/q2cli/builtin/info.py
@@ -89,7 +89,7 @@ def info(config_level):
     if config_level:
         click.secho('To get help with configuring and/or understanding '
                     'QIIME 2 parallelization, visit '
-                    'https://develop.qiime2.org/en/latest/framework/'
-                    'how-to-guides/parallel-configuration.html')
+                    'https://use.qiime2.org/en/latest/references/'
+                    'parallel-configuration.html')
 
     click.secho('\n')


### PR DESCRIPTION
This looks like the following now:

```shell
$ qiime info
System versions
Python version: 3.10.14
QIIME 2 release: 2024.10
QIIME 2 version: 2024.10.0.dev0+17.g5fb10c4
q2cli version: 2019.7.0.dev0+152.g76b8d1e.dirty

Installed plugins
metadata: 2024.10.0.dev0
types: 2024.10.0.dev0+22.g08bae72

Application config directory
/Users/jgc/miniconda3/envs/q2dev-2024.10/var/q2cli

Config
Config Source: /Users/jgc/miniconda3/envs/q2dev-2024.10/etc/qiime2_config.toml

Getting help
To get help with QIIME 2, visit https://qiime2.org
To get help with configuring and/or understanding QIIME 2 parallelization, visit https://use.qiime2.org/en/latest/references/parallel-configuration.html
```

fixes #342

