### PR TITLE
MAINT: click stdout/stderr behavior and set pin

### DIFF
--- a/bin/tab-qiime
+++ b/bin/tab-qiime
@@ -51,4 +51,4 @@ complete -F _qiime_completion -o default -o bashdefault qiime
 # Ignore stdout to avoid displaying help text to users enabling tab-completion.
 # stderr displays the note about cache refreshing, as that can take a few
 # moments to complete.
-qiime > /dev/null
+qiime &> /dev/null

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   run:
   - python  {{ python }}
   - setuptools
-  - click >=8.1
+  - click {{ click }}
   - qiime2 >={{ qiime2 }}
   build:
   - python {{ python }}


### PR DESCRIPTION
Waiting on https://github.com/qiime2/distributions/pull/751

Fixes a future issue we will see where the `tab-qiime` script will run `qiime` to initialize things, however this has changed to print to stderr, which conda will interpret as a hook failure, boggling up the whole deal.