### PR TITLE
IMP: add test-deployment command

### DIFF
--- a/q2cli/builtin/dev.py
+++ b/q2cli/builtin/dev.py
@@ -36,18 +36,19 @@ def refresh_cache():
 
 @dev.command(name="test-deployment",
              short_help="Test deployed QIIME 2 packages and plugins.",
-             help="Run the discoverable for all currently deployed "
+             help="Run the discoverable tests for all currently deployed "
                   "QIIME 2 packages and plugins. Tests are discovered "
-                  "using `python -m unittest discover`. The command is "
-                  "experimental and its interface is subject to change.",
+                  "using `python -m unittest discover`. WARNING: This "
+                  "command is experimental and its interface is subject to "
+                  "change.",
              cls=ToolCommand)
 @click.option("--skip", multiple=True,
               help="Package names to skip during testing. "
                    "Can be specified multiple times.")
-def test_deployment(skip):
-    # TODO: Allow user to pass specific targets on the cli (this would
-    # override internal determination of targets).
-    # TODO: Allow user to list the targets but not run the tests.
+@click.option("--dry-run", is_flag=True, default=False,
+              help="List packages that would be tested but don't run the "
+                   "tests.")
+def test_deployment(skip, dry_run):
     import subprocess
     import q2cli.util
     import os
@@ -78,7 +79,15 @@ def test_deployment(skip):
     # collect the non-plugin packages to test
     nonplugin_targets = {'qiime2', 'q2cli', 'q2templates'} - skip
 
-    # run the plugin tests - QIIMETEST environment variable should not
+    # Handle dry run
+    if dry_run:
+        targets = plugin_targets | nonplugin_targets
+        click.echo(f"Would test {len(targets)} targets:")
+        for target in sorted(targets):
+            click.echo(f"  - {target}")
+        return 0
+
+    # run the plugin tests - QIIMETEST environment variable should not be set
     results = _run_tests(plugin_targets, env)
 
     # run nonplugin tests with the QIIMETEST environment variable set
@@ -86,22 +95,21 @@ def test_deployment(skip):
     results.extend(_run_tests(nonplugin_targets, env))
 
     # Report a summary of the results
-    click.echo("\n" + "="*80)
+    click.echo("\n" + "="*60)
     click.echo("TEST RESULTS SUMMARY")
-    click.echo("="*80)
-    click.echo(f"{'Package':<50} {'Status':<10} {'Exit Code':<10}")
-    click.echo("-" * 80)
+    click.echo("="*60)
+    click.echo(f"{'Package':<50} {'Status':<10}")
+    click.echo("-" * 60)
 
     for i, result in enumerate(results):
         # alternate bolding and not bolding to make table easier to read
         bold = i % 2 == 0
         click.secho(f"{result['package']:<50} "
-                    f"{result['status']:<10} "
-                    f"{result['exit_code']:<10}", bold=bold)
+                    f"{result['status']:<10} ", bold=bold)
 
     passed = sum(1 for r in results if r['status'] == 'PASS')
     failed = len(results) - passed
-    click.echo("-" * 80)
+    click.echo("-" * 60)
     click.echo(f"Total: {len(results)}, Passed: {passed}, Failed: {failed}")
 
     return 1 if failed > 0 else 0

--- a/q2cli/builtin/dev.py
+++ b/q2cli/builtin/dev.py
@@ -34,66 +34,79 @@ def refresh_cache():
     q2cli.core.cache.CACHE.refresh()
 
 
-@dev.command(name='test-deployment',
-             short_help='Test deployed QIIME 2 packages and plugins.',
+@dev.command(name="test-deployment",
+             short_help="Test deployed QIIME 2 packages and plugins.",
              help="Run the discoverable for all currently deployed "
                   "QIIME 2 packages and plugins. Tests are discovered "
-                  "using `python -m unittest discover`.",
+                  "using `python -m unittest discover`. The command is "
+                  "experimental and its interface is subject to change.",
              cls=ToolCommand)
-def test_deployment():
+@click.option("--skip", multiple=True, 
+              help="Package names to skip during testing. "
+                   "Can be specified multiple times.")
+def test_deployment(skip):
     # TODO: Allow user to pass specific targets on the cli (this would 
     # override internal determination of targets).
-    # TODO: Allow user to specify targets to skip on the cli (this would
-    # subtract from internally determined targets).
     # TODO: Allow user to list the targets but not run the tests.
     import subprocess
     import q2cli.util
     import os
     from itertools import cycle
 
-    os.environ['QIIMETEST'] = '1'
+    env = os.environ.copy()
 
-    targets = {'qiime2', 'q2cli', 'q2templates'}
+    skip = set(target.replace('-', '_') for target in skip)
+
+    def _run_tests(targets, env):
+        results = []
+        for target in sorted(targets):
+            click.secho(f"Testing target: {target}", fg='green')
+            cmd = ['python', '-m', 'unittest', 'discover', '-s', target]
+            result = subprocess.run(cmd, env=env)
+            status = "PASS" if result.returncode == 0 else "FAIL"
+            results.append({
+                'package': target,
+                'status': status,
+                'exit_code': result.returncode,
+                'stderr': result.stderr
+            })
+        return results
+
+    # collect the plugins to test 
     pm = q2cli.util.get_plugin_manager()
-    for plugin in pm.plugins.values():
-        targets.add(plugin.package)
-    targets = sorted(targets)
+    plugin_targets = {plugin.package for plugin in pm.plugins.values()}  - skip
 
-    results = [] 
-    for target in targets:
-        click.secho(f"Testing target: {target}", fg='green')
-        result = subprocess.run([
-            'python', '-m', 'unittest', 'discover',
-            '-s', target,
-            '-v'  # verbose
-        ], env=os.environ.copy())
-        status = "PASS" if result.returncode == 0 else "FAIL"
-        results.append({
-            'package': target,
-            'status': status,
-            'exit_code': result.returncode,
-            'stderr': result.stderr
-        })
-
-    # Display a report
-    click.echo("\n" + "="*60)
-    click.echo("TEST RESULTS SUMMARY")
-    click.echo("="*60)
-    click.echo(f"{'Package':<50} {'Status':<10} {'Exit Code':<10}")
-    click.echo("-" * 60)
+    # collect the non-plugin packages to test
+    nonplugin_targets = {'qiime2', 'q2cli', 'q2templates'} - skip
     
-    colors = cycle([None, 'bright_black'])
-    for result, color in zip(results, colors):
+    # run the plugin tests - QIIMETEST environment variable should not
+    results = _run_tests(plugin_targets, env)
+
+    # run nonplugin tests with the QIIMETEST environment variable set
+    env['QIIMETEST'] = '1'
+    results.extend(_run_tests(nonplugin_targets,env))
+
+    # Report a summary of the results
+    click.echo("\n" + "="*80)
+    click.echo("TEST RESULTS SUMMARY")
+    click.echo("="*80)
+    click.echo(f"{'Package':<50} {'Status':<10} {'Exit Code':<10}")
+    click.echo("-" * 80)
+    
+    for i, result in enumerate(results):
+        # alternate bolding and not bolding to make table easier to read
+        bold = i % 2 == 0
         click.secho(f"{result['package']:<50} "
                     f"{result['status']:<10} "
-                    f"{result['exit_code']:<10}", bg=color)
+                    f"{result['exit_code']:<10}", bold=bold)
     
     passed = sum(1 for r in results if r['status'] == 'PASS')
     failed = len(results) - passed
-    click.echo("-" * 60)
+    click.echo("-" * 80)
     click.echo(f"Total: {len(results)}, Passed: {passed}, Failed: {failed}")
     
     return 1 if failed > 0 else 0
+
 
 import_theme_help = \
     ("Allows for customization of q2cli's command line styling based on an "

--- a/q2cli/builtin/dev.py
+++ b/q2cli/builtin/dev.py
@@ -41,17 +41,16 @@ def refresh_cache():
                   "using `python -m unittest discover`. The command is "
                   "experimental and its interface is subject to change.",
              cls=ToolCommand)
-@click.option("--skip", multiple=True, 
+@click.option("--skip", multiple=True,
               help="Package names to skip during testing. "
                    "Can be specified multiple times.")
 def test_deployment(skip):
-    # TODO: Allow user to pass specific targets on the cli (this would 
+    # TODO: Allow user to pass specific targets on the cli (this would
     # override internal determination of targets).
     # TODO: Allow user to list the targets but not run the tests.
     import subprocess
     import q2cli.util
     import os
-    from itertools import cycle
 
     env = os.environ.copy()
 
@@ -72,19 +71,19 @@ def test_deployment(skip):
             })
         return results
 
-    # collect the plugins to test 
+    # collect the plugins to test
     pm = q2cli.util.get_plugin_manager()
-    plugin_targets = {plugin.package for plugin in pm.plugins.values()}  - skip
+    plugin_targets = {plugin.package for plugin in pm.plugins.values()} - skip
 
     # collect the non-plugin packages to test
     nonplugin_targets = {'qiime2', 'q2cli', 'q2templates'} - skip
-    
+
     # run the plugin tests - QIIMETEST environment variable should not
     results = _run_tests(plugin_targets, env)
 
     # run nonplugin tests with the QIIMETEST environment variable set
     env['QIIMETEST'] = '1'
-    results.extend(_run_tests(nonplugin_targets,env))
+    results.extend(_run_tests(nonplugin_targets, env))
 
     # Report a summary of the results
     click.echo("\n" + "="*80)
@@ -92,19 +91,19 @@ def test_deployment(skip):
     click.echo("="*80)
     click.echo(f"{'Package':<50} {'Status':<10} {'Exit Code':<10}")
     click.echo("-" * 80)
-    
+
     for i, result in enumerate(results):
         # alternate bolding and not bolding to make table easier to read
         bold = i % 2 == 0
         click.secho(f"{result['package']:<50} "
                     f"{result['status']:<10} "
                     f"{result['exit_code']:<10}", bold=bold)
-    
+
     passed = sum(1 for r in results if r['status'] == 'PASS')
     failed = len(results) - passed
     click.echo("-" * 80)
     click.echo(f"Total: {len(results)}, Passed: {passed}, Failed: {failed}")
-    
+
     return 1 if failed > 0 else 0
 
 

--- a/q2cli/builtin/dev.py
+++ b/q2cli/builtin/dev.py
@@ -36,8 +36,9 @@ def refresh_cache():
 
 @dev.command(name='test-deployment',
              short_help='Test deployed QIIME 2 packages and plugins.',
-             help="Run the discoverable unit tests for all currently "
-                  "deployed QIIME 2 packages and plugins.",
+             help="Run the discoverable for all currently deployed "
+                  "QIIME 2 packages and plugins. Tests are discovered "
+                  "using `python -m unittest discover`.",
              cls=ToolCommand)
 def test_deployment():
     # TODO: Allow user to pass specific targets on the cli (this would 
@@ -45,21 +46,54 @@ def test_deployment():
     # TODO: Allow user to specify targets to skip on the cli (this would
     # subtract from internally determined targets).
     # TODO: Allow user to list the targets but not run the tests.
-    import pytest
+    import subprocess
     import q2cli.util
-    
+    import os
+    from itertools import cycle
+
+    os.environ['QIIMETEST'] = '1'
+
     targets = {'qiime2', 'q2cli', 'q2templates'}
     pm = q2cli.util.get_plugin_manager()
     for plugin in pm.plugins.values():
-        targets.add(plugin.project_name)
-    # for target in targets:
-    #     click.echo(target)
+        targets.add(plugin.package)
+    targets = sorted(targets)
 
+    results = [] 
     for target in targets:
-        click.echo(f"Testing target: {target}")
-        pytest.main(['--pyargs', target])
-    
+        click.secho(f"Testing target: {target}", fg='green')
+        result = subprocess.run([
+            'python', '-m', 'unittest', 'discover',
+            '-s', target,
+            '-v'  # verbose
+        ], env=os.environ.copy())
+        status = "PASS" if result.returncode == 0 else "FAIL"
+        results.append({
+            'package': target,
+            'status': status,
+            'exit_code': result.returncode,
+            'stderr': result.stderr
+        })
 
+    # Display a report
+    click.echo("\n" + "="*60)
+    click.echo("TEST RESULTS SUMMARY")
+    click.echo("="*60)
+    click.echo(f"{'Package':<50} {'Status':<10} {'Exit Code':<10}")
+    click.echo("-" * 60)
+    
+    colors = cycle([None, 'bright_black'])
+    for result, color in zip(results, colors):
+        click.secho(f"{result['package']:<50} "
+                    f"{result['status']:<10} "
+                    f"{result['exit_code']:<10}", bg=color)
+    
+    passed = sum(1 for r in results if r['status'] == 'PASS')
+    failed = len(results) - passed
+    click.echo("-" * 60)
+    click.echo(f"Total: {len(results)}, Passed: {passed}, Failed: {failed}")
+    
+    return 1 if failed > 0 else 0
 
 import_theme_help = \
     ("Allows for customization of q2cli's command line styling based on an "

--- a/q2cli/builtin/dev.py
+++ b/q2cli/builtin/dev.py
@@ -34,6 +34,33 @@ def refresh_cache():
     q2cli.core.cache.CACHE.refresh()
 
 
+@dev.command(name='test-deployment',
+             short_help='Test deployed QIIME 2 packages and plugins.',
+             help="Run the discoverable unit tests for all currently "
+                  "deployed QIIME 2 packages and plugins.",
+             cls=ToolCommand)
+def test_deployment():
+    # TODO: Allow user to pass specific targets on the cli (this would 
+    # override internal determination of targets).
+    # TODO: Allow user to specify targets to skip on the cli (this would
+    # subtract from internally determined targets).
+    # TODO: Allow user to list the targets but not run the tests.
+    import pytest
+    import q2cli.util
+    
+    targets = {'qiime2', 'q2cli', 'q2templates'}
+    pm = q2cli.util.get_plugin_manager()
+    for plugin in pm.plugins.values():
+        targets.add(plugin.project_name)
+    # for target in targets:
+    #     click.echo(target)
+
+    for target in targets:
+        click.echo(f"Testing target: {target}")
+        pytest.main(['--pyargs', target])
+    
+
+
 import_theme_help = \
     ("Allows for customization of q2cli's command line styling based on an "
      "imported .theme (INI formatted) file. If you are unfamiliar with .ini "

--- a/q2cli/builtin/dev.py
+++ b/q2cli/builtin/dev.py
@@ -39,33 +39,38 @@ def refresh_cache():
              help="Run the discoverable tests for all currently deployed "
                   "QIIME 2 packages and plugins. Tests are discovered "
                   "using `python -m unittest discover`. WARNING: This "
-                  "command is experimental and its interface is subject to "
-                  "change.",
+                  "command is experimental: its interface is subject to "
+                  "change, and some tests may fail on some systems due to "
+                  "configuration issues.",
              cls=ToolCommand)
 @click.option("--skip", multiple=True,
-              help="Package names to skip during testing. "
+              help="Package to skip during testing. This is ignored if "
+                   "--target is provided. Can be specified multiple times.")
+@click.option("--target", multiple=True,
+              help="Package to test. Defaults to all discovered packages. "
                    "Can be specified multiple times.")
 @click.option("--dry-run", is_flag=True, default=False,
               help="List packages that would be tested but don't run the "
                    "tests.")
-def test_deployment(skip, dry_run):
+def test_deployment(skip, target, dry_run):
     import subprocess
     import q2cli.util
     import os
 
     env = os.environ.copy()
 
-    skip = set(target.replace('-', '_') for target in skip)
+    skip = set(s.replace('-', '_') for s in skip)
+    target = set(t.replace('-', '_') for t in target)
 
     def _run_tests(targets, env):
         results = []
-        for target in sorted(targets):
-            click.secho(f"Testing target: {target}", fg='green')
-            cmd = ['python', '-m', 'unittest', 'discover', '-s', target]
+        for t in sorted(targets):
+            click.secho(f"Testing target: {t}", fg='green')
+            cmd = ['python', '-m', 'unittest', 'discover', '-s', t]
             result = subprocess.run(cmd, env=env)
             status = "PASS" if result.returncode == 0 else "FAIL"
             results.append({
-                'package': target,
+                'package': t,
                 'status': status,
                 'exit_code': result.returncode,
                 'stderr': result.stderr
@@ -74,18 +79,30 @@ def test_deployment(skip, dry_run):
 
     # collect the plugins to test
     pm = q2cli.util.get_plugin_manager()
-    plugin_targets = {plugin.package for plugin in pm.plugins.values()} - skip
+    plugin_targets = {plugin.package for plugin in pm.plugins.values()}
 
     # collect the non-plugin packages to test
-    nonplugin_targets = {'qiime2', 'q2cli', 'q2templates'} - skip
+    nonplugin_targets = {'qiime2', 'q2cli', 'q2templates'}
+
+    # handle target or skip parameter
+    if len(target) > 0:
+        plugin_targets = plugin_targets & target
+        nonplugin_targets = nonplugin_targets & target
+    else:
+        plugin_targets = plugin_targets - skip
+        nonplugin_targets = nonplugin_targets - skip
+
+    if len(plugin_targets) + len(nonplugin_targets) == 0:
+        click.echo("No targets found. Nothing to test.")
+        return
 
     # Handle dry run
     if dry_run:
         targets = plugin_targets | nonplugin_targets
         click.echo(f"Would test {len(targets)} targets:")
-        for target in sorted(targets):
-            click.echo(f"  - {target}")
-        return 0
+        for t in sorted(targets):
+            click.echo(f"  - {t}")
+        return
 
     # run the plugin tests - QIIMETEST environment variable should not be set
     results = _run_tests(plugin_targets, env)
@@ -112,7 +129,7 @@ def test_deployment(skip, dry_run):
     click.echo("-" * 60)
     click.echo(f"Total: {len(results)}, Passed: {passed}, Failed: {failed}")
 
-    return 1 if failed > 0 else 0
+    return
 
 
 import_theme_help = \

--- a/q2cli/tests/test_dev.py
+++ b/q2cli/tests/test_dev.py
@@ -79,8 +79,7 @@ class TestDev(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
 
     # test-deployment
-    def test_test_deployment(self):
-        # confirm that the command exists and is callable
+    def test_test_deployment_dry_run(self):
         result = self.runner.invoke(dev,
                                     ['test-deployment',
                                      '--dry-run',
@@ -88,9 +87,17 @@ class TestDev(unittest.TestCase):
         expected_regex1 = r'Would test \d+ targets:'
         expected_regex2 = r'q2cli'
 
-        self.assertEqual(result.exit_code, 0)
         self.assertRegex(result.stdout, expected_regex1)
         self.assertRegex(result.stdout, expected_regex2)
+
+    def test_test_deployment_target(self):
+        result = self.runner.invoke(dev,
+                                    ['test-deployment',
+                                     '--target', 'not-a-plugin'
+                                     ])
+        expected_regex1 = r'Nothing to test.'
+
+        self.assertRegex(result.stdout, expected_regex1)
 
     # result_type & result_data tests
     def test_assert_result_type_artifact_success(self):

--- a/q2cli/tests/test_dev.py
+++ b/q2cli/tests/test_dev.py
@@ -78,6 +78,15 @@ class TestDev(unittest.TestCase):
             dev, ['reset-theme'])
         self.assertNotEqual(result.exit_code, 0)
 
+    # test-deployment
+    def test_test_deployment(self):
+        # confirm that the command exists and is callable
+        result = self.runner.invoke(dev,
+                                    ['test-deployment',
+                                     '--help',
+                                     ])
+        self.assertEqual(result.exit_code, 0)
+
     # result_type & result_data tests
     def test_assert_result_type_artifact_success(self):
         result = self.runner.invoke(dev,

--- a/q2cli/tests/test_dev.py
+++ b/q2cli/tests/test_dev.py
@@ -83,9 +83,14 @@ class TestDev(unittest.TestCase):
         # confirm that the command exists and is callable
         result = self.runner.invoke(dev,
                                     ['test-deployment',
-                                     '--help',
+                                     '--dry-run',
                                      ])
+        expected_regex1 = r'Would test \d+ targets:'
+        expected_regex2 = r'q2cli'
+
         self.assertEqual(result.exit_code, 0)
+        self.assertRegex(result.stdout, expected_regex1)
+        self.assertRegex(result.stdout, expected_regex2)
 
     # result_type & result_data tests
     def test_assert_result_type_artifact_success(self):


### PR DESCRIPTION
This PR would be nice to have merged for 2025.7, since we'll be teaching using the Docker container at the Snowbird workshop in September. Since it hasn't had a lot of testing yet, I put a warning in the help text on the command that it's subject to change. 

Relatively quick command that is useful for testing in a `tiny` environment:

```
qiime dev test-deployment --skip qiime2 --skip q2cli --skip q2-types
```

Output includes the typical unit test output (pages and pages and pages), and then the following summary:

```
============================================================
TEST RESULTS SUMMARY
============================================================
Package                                            Status
------------------------------------------------------------
q2_metadata                                        PASS
q2_types                                           PASS
q2templates                                        PASS
------------------------------------------------------------
Total: 3, Passed: 3, Failed: 0
```