### PR TITLE
PATCH: fix annotation-fetch --verbose for signatures

### DIFF
--- a/q2cli/builtin/tools.py
+++ b/q2cli/builtin/tools.py
@@ -1640,9 +1640,18 @@ def annotation_fetch(input_path, name, verbose):
     click.echo(CONFIG.cfg_style('type', "type")+":      ", nl=False)
     click.echo(annotation.annotation_type)
     if verbose:
-        click.echo('', nl=True)
-        click.echo(CONFIG.cfg_style('type', "contents")+":  ", nl=False)
-        click.echo(annotation.contents)
+        if annotation.annotation_type == 'Signature':
+            click.echo('', nl=True)
+            click.echo(CONFIG.cfg_style('type', "signer_name")+": ", nl=False)
+            click.echo(annotation.signer_name)
+            click.echo(CONFIG.cfg_style('type', "signer_email")+": ", nl=False)
+            click.echo(annotation.signer_email)
+            click.echo(CONFIG.cfg_style('type', "fingerprint")+": ", nl=False)
+            click.echo(annotation.fingerprint)
+        else:
+            click.echo('', nl=True)
+            click.echo(CONFIG.cfg_style('type', "contents")+":  ", nl=False)
+            click.echo(annotation.contents)
 
 
 @tools.command(


### PR DESCRIPTION
fixes a minor bug - when running `annotation-fetch` with the verbose flag enabled for a signature annotation, an error is raised bc there are no contents associated with a signature. this has been replaced with the output including the signer name/email and fingerprint.

one thing to note is that i didn't include a unit test for this bc there's no quick way to create an artifact with a signature on it using the dummy plugin. cc @Oddant1 